### PR TITLE
Fix filtering issue and missing using

### DIFF
--- a/BoothDownloadApp/DownloadItem.cs
+++ b/BoothDownloadApp/DownloadItem.cs
@@ -1,4 +1,5 @@
-﻿namespace BoothDownloadApp
+using System;
+namespace BoothDownloadApp
 {
     public class DownloadItem
     {


### PR DESCRIPTION
## Summary
- add missing `using System;` for `ArgumentNullException`
- implement `ApplyFilters` functionality and update UI after status changes

## Testing
- `dotnet build BoothDownloadApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffd98bcec832d9fd288e879b36b68