### PR TITLE
Add MAUI front-end with shared core

### DIFF
--- a/BoothDownloadApp.Core/BoothDownloadApp.Core.csproj
+++ b/BoothDownloadApp.Core/BoothDownloadApp.Core.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/BoothDownloadApp.Core/Models/BoothItem.cs
+++ b/BoothDownloadApp.Core/Models/BoothItem.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
+
+namespace BoothDownloadApp.Core;
+
+public class BoothItem : INotifyPropertyChanged
+{
+    private bool _isSelected;
+    private bool _isDownloaded;
+
+    [JsonPropertyName("productName")]
+    public string ProductName { get; set; } = string.Empty;
+
+    [JsonPropertyName("shopName")]
+    public string ShopName { get; set; } = string.Empty;
+
+    [JsonPropertyName("thumbnail")]
+    public string Thumbnail { get; set; } = string.Empty;
+
+    [JsonPropertyName("downloads")]
+    public List<DownloadInfo> Downloads { get; set; } = new();
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set
+        {
+            if (_isSelected != value)
+            {
+                _isSelected = value;
+                OnPropertyChanged();
+                foreach (var d in Downloads)
+                    d.IsSelected = value;
+            }
+        }
+    }
+
+    [JsonIgnore]
+    public bool IsDownloaded
+    {
+        get => _isDownloaded;
+        set
+        {
+            if (_isDownloaded != value)
+            {
+                _isDownloaded = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    protected void OnPropertyChanged([CallerMemberName] string propertyName = null!)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+    public class DownloadInfo : INotifyPropertyChanged
+    {
+        private bool _isSelected;
+        private bool _isDownloaded;
+
+        [JsonPropertyName("fileName")]
+        public string FileName { get; set; } = string.Empty;
+
+        [JsonPropertyName("downloadLink")]
+        public string DownloadLink { get; set; } = string.Empty;
+
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set
+            {
+                if (_isSelected != value)
+                {
+                    _isSelected = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        [JsonIgnore]
+        public bool IsDownloaded
+        {
+            get => _isDownloaded;
+            set
+            {
+                if (_isDownloaded != value)
+                {
+                    _isDownloaded = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null!)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/BoothDownloadApp.Core/Models/BoothLibrary.cs
+++ b/BoothDownloadApp.Core/Models/BoothLibrary.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace BoothDownloadApp.Core;
+
+public class BoothLibrary
+{
+    [JsonPropertyName("library")]
+    public List<BoothItem> Library { get; set; } = new();
+}

--- a/BoothDownloadApp.Core/Services/BoothDataService.cs
+++ b/BoothDownloadApp.Core/Services/BoothDataService.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace BoothDownloadApp.Core;
+
+public static class BoothDataService
+{
+    private static readonly JsonSerializerOptions Options = new() { WriteIndented = true, PropertyNameCaseInsensitive = true };
+
+    public static async Task<List<BoothItem>> LoadAsync(string path)
+    {
+        if (!File.Exists(path))
+            return new List<BoothItem>();
+        await using var fs = File.OpenRead(path);
+        var lib = await JsonSerializer.DeserializeAsync<BoothLibrary>(fs, Options);
+        return lib?.Library ?? new List<BoothItem>();
+    }
+
+    public static async Task SaveAsync(string path, IEnumerable<BoothItem> items)
+    {
+        var lib = new BoothLibrary { Library = items.ToList() };
+        await using var fs = File.Create(path);
+        await JsonSerializer.SerializeAsync(fs, lib, Options);
+    }
+}

--- a/BoothDownloadApp.Core/Services/Downloader.cs
+++ b/BoothDownloadApp.Core/Services/Downloader.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BoothDownloadApp.Core;
+
+public static class Downloader
+{
+    public static async Task DownloadAsync(BoothItem item, string baseFolder, IProgress<double>? progress = null, CancellationToken token = default)
+    {
+        using HttpClient client = new();
+        string itemFolder = Path.Combine(baseFolder, item.ShopName, item.ProductName);
+        Directory.CreateDirectory(itemFolder);
+
+        var selected = item.Downloads.Where(d => d.IsSelected).ToList();
+        int total = selected.Count;
+        int count = 0;
+
+        foreach (var file in selected)
+        {
+            string path = Path.Combine(itemFolder, file.FileName);
+            using var response = await client.GetAsync(file.DownloadLink, token);
+            response.EnsureSuccessStatusCode();
+            await using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+            await response.Content.CopyToAsync(fs, token);
+            file.IsDownloaded = true;
+            count++;
+            progress?.Report((double)count / total);
+        }
+
+        item.IsDownloaded = item.Downloads.All(d => d.IsDownloaded);
+    }
+}

--- a/BoothDownloadApp.Maui/App.xaml
+++ b/BoothDownloadApp.Maui/App.xaml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="BoothDownloadApp.Maui.App">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/BoothDownloadApp.Maui/App.xaml.cs
+++ b/BoothDownloadApp.Maui/App.xaml.cs
@@ -1,0 +1,13 @@
+using Microsoft.Maui.Controls;
+
+namespace BoothDownloadApp.Maui;
+
+public partial class App : Application
+{
+    public App()
+    {
+        InitializeComponent();
+        MainPage = new MainPage();
+    }
+}
+

--- a/BoothDownloadApp.Maui/BoothDownloadApp.Maui.csproj
+++ b/BoothDownloadApp.Maui/BoothDownloadApp.Maui.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseMaui>true</UseMaui>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BoothDownloadApp.Core\BoothDownloadApp.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/BoothDownloadApp.Maui/MainPage.xaml
+++ b/BoothDownloadApp.Maui/MainPage.xaml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="BoothDownloadApp.Maui.MainPage"
+             Title="Booth Downloader">
+    <StackLayout Padding="20" Spacing="10">
+        <Button Text="Load JSON" Command="{Binding LoadCommand}" />
+        <CollectionView ItemsSource="{Binding Items}" HeightRequest="300">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <StackLayout Orientation="Horizontal" Padding="5">
+                        <CheckBox IsChecked="{Binding IsSelected}" />
+                        <Label Text="{Binding ProductName}" VerticalOptions="Center" />
+                    </StackLayout>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+        <Button Text="Start Download" Command="{Binding DownloadCommand}" />
+    </StackLayout>
+</ContentPage>

--- a/BoothDownloadApp.Maui/MainPage.xaml.cs
+++ b/BoothDownloadApp.Maui/MainPage.xaml.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
+using BoothDownloadApp.Core;
+
+namespace BoothDownloadApp.Maui;
+
+public partial class MainPage : ContentPage
+{
+    private readonly string manageFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "booth_manage.json");
+
+    public ObservableCollection<BoothItem> Items { get; } = new();
+
+    public ICommand LoadCommand { get; }
+    public ICommand DownloadCommand { get; }
+
+    public MainPage()
+    {
+        InitializeComponent();
+        BindingContext = this;
+        LoadCommand = new Command(async () => await LoadAsync());
+        DownloadCommand = new Command(async () => await DownloadAsync());
+    }
+
+    private async Task LoadAsync()
+    {
+        var items = await BoothDataService.LoadAsync(manageFilePath);
+        Items.Clear();
+        foreach (var item in items)
+            Items.Add(item);
+    }
+
+    private async Task DownloadAsync()
+    {
+        string folder = Path.Combine(FileSystem.AppDataDirectory, "Downloads");
+        foreach (var item in Items.Where(i => i.IsSelected || i.Downloads.Any(d => d.IsSelected)))
+        {
+            await Downloader.DownloadAsync(item, folder);
+        }
+    }
+}
+

--- a/BoothDownloadApp.Maui/MauiProgram.cs
+++ b/BoothDownloadApp.Maui/MauiProgram.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Logging;
+
+namespace BoothDownloadApp.Maui;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>()
+            .ConfigureFonts(fonts =>
+            {
+                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+            });
+
+#if DEBUG
+        builder.Logging.AddDebug();
+#endif
+
+        return builder.Build();
+    }
+}
+

--- a/BoothDownloadApp.Maui/Program.cs
+++ b/BoothDownloadApp.Maui/Program.cs
@@ -1,0 +1,16 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace BoothDownloadApp.Maui;
+
+class Program : MauiApplication
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+    static void Main(string[] args)
+    {
+        var app = new Program();
+        app.Run(args);
+    }
+}
+

--- a/BoothDownloadApp.sln
+++ b/BoothDownloadApp.sln
@@ -5,6 +5,10 @@ VisualStudioVersion = 17.13.35913.81 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoothDownloadApp", "BoothDownloadApp\BoothDownloadApp.csproj", "{F806D4F7-E031-4240-8640-A72D2D59875F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoothDownloadApp.Core", "BoothDownloadApp.Core\BoothDownloadApp.Core.csproj", "{B1D2C893-AB22-42BF-B8E9-32749961579D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoothDownloadApp.Maui", "BoothDownloadApp.Maui\BoothDownloadApp.Maui.csproj", "{24C80BAC-0287-476A-A035-C919B07D2087}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,8 +18,16 @@ Global
 		{F806D4F7-E031-4240-8640-A72D2D59875F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F806D4F7-E031-4240-8640-A72D2D59875F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F806D4F7-E031-4240-8640-A72D2D59875F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F806D4F7-E031-4240-8640-A72D2D59875F}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {F806D4F7-E031-4240-8640-A72D2D59875F}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B1D2C893-AB22-42BF-B8E9-32749961579D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B1D2C893-AB22-42BF-B8E9-32749961579D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B1D2C893-AB22-42BF-B8E9-32749961579D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B1D2C893-AB22-42BF-B8E9-32749961579D}.Release|Any CPU.Build.0 = Release|Any CPU
+                {24C80BAC-0287-476A-A035-C919B07D2087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {24C80BAC-0287-476A-A035-C919B07D2087}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {24C80BAC-0287-476A-A035-C919B07D2087}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {24C80BAC-0287-476A-A035-C919B07D2087}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/BoothDownloadApp/BoothDownloadApp.csproj
+++ b/BoothDownloadApp/BoothDownloadApp.csproj
@@ -25,6 +25,8 @@
     <PackageReference Include="System.Drawing.Common" Version="9.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\BoothDownloadApp.Core\BoothDownloadApp.Core.csproj" />
   </ItemGroup>
 
 </Project>
+


### PR DESCRIPTION
## Summary
- add `BoothDownloadApp.Core` project with models and basic services
- add `BoothDownloadApp.Maui` project implementing a simple cross-platform UI
- reference the new core library from WPF and MAUI
- update solution with new projects

## Testing
- `dotnet build BoothDownloadApp.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840004580e0832da4aaefaeef602b43