### PR TITLE
Add cross-platform MAUI front-end

### DIFF
--- a/BoothDownloadApp.Maui/App.xaml
+++ b/BoothDownloadApp.Maui/App.xaml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="BoothDownloadApp.Maui.App">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/BoothDownloadApp.Maui/App.xaml.cs
+++ b/BoothDownloadApp.Maui/App.xaml.cs
@@ -1,0 +1,16 @@
+using System;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Application = Microsoft.Maui.Controls.Application;
+
+namespace BoothDownloadApp.Maui
+{
+    public partial class App : Application
+    {
+        public App()
+        {
+            InitializeComponent();
+            MainPage = new NavigationPage(new MainPage());
+        }
+    }
+}

--- a/BoothDownloadApp.Maui/BoothDownloadApp.Maui.csproj
+++ b/BoothDownloadApp.Maui/BoothDownloadApp.Maui.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BoothDownloadApp.Core\BoothDownloadApp.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/BoothDownloadApp.Maui/MainPage.xaml
+++ b/BoothDownloadApp.Maui/MainPage.xaml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:b="clr-namespace:BoothDownloadApp"
+             x:Class="BoothDownloadApp.Maui.MainPage">
+    <ContentPage.Content>
+        <VerticalStackLayout Spacing="10" Padding="20">
+            <Button Text="Load JSON" Clicked="OnLoadJsonClicked" />
+            <CollectionView ItemsSource="{Binding Items}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="b:BoothItem">
+                        <StackLayout Padding="5" BackgroundColor="LightGray" Margin="0,5">
+                            <CheckBox IsChecked="{Binding IsSelected}" />
+                            <Label Text="{Binding ProductName}" FontAttributes="Bold" />
+                            <Label Text="{Binding ShopName}" FontSize="12" />
+                            <CollectionView ItemsSource="{Binding Downloads}">
+                                <CollectionView.ItemTemplate>
+                                    <DataTemplate x:DataType="b:BoothItem.DownloadInfo">
+                                        <StackLayout Orientation="Horizontal" Spacing="5">
+                                            <CheckBox IsChecked="{Binding IsSelected}" />
+                                            <Label Text="{Binding FileName}" />
+                                        </StackLayout>
+                                    </DataTemplate>
+                                </CollectionView.ItemTemplate>
+                            </CollectionView>
+                        </StackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+            <Button Text="Start Download" Clicked="OnStartDownloadClicked" />
+        </VerticalStackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/BoothDownloadApp.Maui/MainPage.xaml.cs
+++ b/BoothDownloadApp.Maui/MainPage.xaml.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
+using BoothDownloadApp;
+using System.Net.Http;
+using System.IO;
+using System.Linq;
+
+namespace BoothDownloadApp.Maui
+{
+    public partial class MainPage : ContentPage
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNameCaseInsensitive = true
+        };
+
+        public ObservableCollection<BoothItem> Items { get; } = new();
+
+        public MainPage()
+        {
+            InitializeComponent();
+            BindingContext = this;
+        }
+
+        private async void OnLoadJsonClicked(object sender, EventArgs e)
+        {
+            try
+            {
+                var result = await FilePicker.Default.PickAsync(new PickOptions
+                {
+                    PickerTitle = "Select booth_data.json"
+                });
+                if (result != null)
+                {
+                    using var stream = await result.OpenReadAsync();
+                    var library = await JsonSerializer.DeserializeAsync<BoothLibrary>(stream, JsonOptions);
+                    if (library?.Library != null)
+                    {
+                        Items.Clear();
+                        foreach (var item in library.Library)
+                        {
+                            Items.Add(item);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                await DisplayAlert("Error", ex.Message, "OK");
+            }
+        }
+
+        private async void OnStartDownloadClicked(object sender, EventArgs e)
+        {
+            var selected = Items.Where(i => i.IsSelected || i.Downloads.Any(d => d.IsSelected)).ToList();
+            if (selected.Count == 0)
+            {
+                await DisplayAlert("Info", "No items selected", "OK");
+                return;
+            }
+            string root = FileSystem.Current.AppDataDirectory;
+            using HttpClient client = new HttpClient();
+            foreach (var item in selected)
+            {
+                string productDir = Path.Combine(root, item.ShopName, item.ProductName);
+                Directory.CreateDirectory(productDir);
+                foreach (var dl in item.Downloads.Where(d => d.IsSelected))
+                {
+                    try
+                    {
+                        string path = Path.Combine(productDir, dl.FileName);
+                        using var response = await client.GetAsync(dl.DownloadLink);
+                        response.EnsureSuccessStatusCode();
+                        await using var fs = File.OpenWrite(path);
+                        await response.Content.CopyToAsync(fs);
+                    }
+                    catch (Exception ex)
+                    {
+                        await DisplayAlert("Download failed", ex.Message, "OK");
+                    }
+                }
+            }
+            await DisplayAlert("Done", "Downloads completed", "OK");
+        }
+    }
+}

--- a/BoothDownloadApp.Maui/MauiProgram.cs
+++ b/BoothDownloadApp.Maui/MauiProgram.cs
@@ -1,0 +1,17 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace BoothDownloadApp.Maui
+{
+    public static class MauiProgram
+    {
+        public static MauiApp CreateMauiApp()
+        {
+            var builder = MauiApp.CreateBuilder();
+            builder
+                .UseMauiApp<App>();
+
+            return builder.Build();
+        }
+    }
+}

--- a/BoothDownloadApp.Maui/Platforms/Android/MainActivity.cs
+++ b/BoothDownloadApp.Maui/Platforms/Android/MainActivity.cs
@@ -1,0 +1,11 @@
+using Android.App;
+using Android.Content.PM;
+using Microsoft.Maui;
+
+namespace BoothDownloadApp.Maui
+{
+    [Activity(Label = "BoothDownloadApp", Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode)]
+    public class MainActivity : MauiAppCompatActivity
+    {
+    }
+}

--- a/BoothDownloadApp.Maui/Platforms/Android/MainApplication.cs
+++ b/BoothDownloadApp.Maui/Platforms/Android/MainApplication.cs
@@ -1,0 +1,16 @@
+using Android.App;
+using Android.Runtime;
+using Microsoft.Maui;
+
+namespace BoothDownloadApp.Maui
+{
+    [Application]
+    public class MainApplication : MauiApplication
+    {
+        public MainApplication(IntPtr handle, JniHandleOwnership ownership) : base(handle, ownership)
+        {
+        }
+
+        protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    }
+}

--- a/BoothDownloadApp.Maui/Platforms/MacCatalyst/AppDelegate.cs
+++ b/BoothDownloadApp.Maui/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,0 +1,11 @@
+using Foundation;
+using Microsoft.Maui;
+
+namespace BoothDownloadApp.Maui
+{
+    [Register("AppDelegate")]
+    public class AppDelegate : MauiUIApplicationDelegate
+    {
+        protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    }
+}

--- a/BoothDownloadApp.Maui/Platforms/MacCatalyst/Program.cs
+++ b/BoothDownloadApp.Maui/Platforms/MacCatalyst/Program.cs
@@ -1,0 +1,13 @@
+using ObjCRuntime;
+using UIKit;
+
+namespace BoothDownloadApp.Maui
+{
+    public class Program
+    {
+        static void Main(string[] args)
+        {
+            UIApplication.Main(args, null, typeof(AppDelegate));
+        }
+    }
+}

--- a/BoothDownloadApp.Maui/Platforms/Windows/App.xaml.cs
+++ b/BoothDownloadApp.Maui/Platforms/Windows/App.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.UI.Xaml;
+
+namespace BoothDownloadApp.Maui
+{
+    public partial class App : MauiWinUIApplication
+    {
+        public App() => InitializeComponent();
+
+        protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    }
+}

--- a/BoothDownloadApp.Maui/Platforms/Windows/Program.cs
+++ b/BoothDownloadApp.Maui/Platforms/Windows/Program.cs
@@ -1,0 +1,15 @@
+using Microsoft.UI.Xaml;
+using System;
+
+namespace BoothDownloadApp.Maui
+{
+    public static class Program
+    {
+        [STAThread]
+        static void Main(string[] args)
+        {
+            var app = new App();
+            app.Run();
+        }
+    }
+}

--- a/BoothDownloadApp.Maui/Platforms/iOS/AppDelegate.cs
+++ b/BoothDownloadApp.Maui/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,11 @@
+using Foundation;
+using Microsoft.Maui;
+
+namespace BoothDownloadApp.Maui
+{
+    [Register("AppDelegate")]
+    public class AppDelegate : MauiUIApplicationDelegate
+    {
+        protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    }
+}

--- a/BoothDownloadApp.Maui/Platforms/iOS/Program.cs
+++ b/BoothDownloadApp.Maui/Platforms/iOS/Program.cs
@@ -1,0 +1,13 @@
+using ObjCRuntime;
+using UIKit;
+
+namespace BoothDownloadApp.Maui
+{
+    public class Program
+    {
+        static void Main(string[] args)
+        {
+            UIApplication.Main(args, null, typeof(AppDelegate));
+        }
+    }
+}

--- a/BoothDownloadApp.sln
+++ b/BoothDownloadApp.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoothDownloadApp", "BoothDo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoothDownloadApp.Core", "BoothDownloadApp.Core\BoothDownloadApp.Core.csproj", "{47A83B1D-BF3B-4A9F-BEE8-607B604B885D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoothDownloadApp.Maui", "BoothDownloadApp.Maui\BoothDownloadApp.Maui.csproj", "{25401983-A326-4FA1-896E-6F629C2CC28A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
                 {47A83B1D-BF3B-4A9F-BEE8-607B604B885D}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {47A83B1D-BF3B-4A9F-BEE8-607B604B885D}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {47A83B1D-BF3B-4A9F-BEE8-607B604B885D}.Release|Any CPU.Build.0 = Release|Any CPU
+                {25401983-A326-4FA1-896E-6F629C2CC28A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {25401983-A326-4FA1-896E-6F629C2CC28A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {25401983-A326-4FA1-896E-6F629C2CC28A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {25401983-A326-4FA1-896E-6F629C2CC28A}.Release|Any CPU.Build.0 = Release|Any CPU
         EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- create BoothDownloadApp.Maui cross‑platform project
- implement MainPage in XAML to load JSON, list items and start downloads
- hook MAUI project into solution

## Testing
- `dotnet build BoothDownloadApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684001627e94832d819818942b559e21