### PR TITLE
Implement settings and history tracking

### DIFF
--- a/BoothDownloadApp.Core/SettingsManager.cs
+++ b/BoothDownloadApp.Core/SettingsManager.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace BoothDownloadApp
+{
+    public static class SettingsManager
+    {
+        private static readonly string SettingsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "settings.json");
+        private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions { WriteIndented = true };
+
+        public static Settings Load()
+        {
+            try
+            {
+                if (File.Exists(SettingsPath))
+                {
+                    string json = File.ReadAllText(SettingsPath);
+                    var settings = JsonSerializer.Deserialize<Settings>(json, JsonOptions);
+                    if (settings != null)
+                    {
+                        return settings;
+                    }
+                }
+            }
+            catch
+            {
+                // ignore and fall back to defaults
+            }
+            return new Settings { DownloadPath = "C:\\BoothData", RetryCount = 3 };
+        }
+
+        public static void Save(Settings settings)
+        {
+            try
+            {
+                string json = JsonSerializer.Serialize(settings, JsonOptions);
+                File.WriteAllText(SettingsPath, json);
+            }
+            catch
+            {
+                // ignore save errors
+            }
+        }
+    }
+}

--- a/BoothDownloadApp/MainWindow.xaml
+++ b/BoothDownloadApp/MainWindow.xaml
@@ -37,7 +37,7 @@
             </StackPanel>
 
             <!-- アイテム一覧領域 -->
-            <ListView Grid.Column="1" Margin="5" ItemsSource="{Binding Items}" SelectionChanged="ListView_SelectionChanged">
+            <ListView x:Name="itemsListView" Grid.Column="1" Margin="5" ItemsSource="{Binding Items}" SelectionChanged="ListView_SelectionChanged">
                 <ListView.View>
                     <GridView>
                         <GridViewColumn Header="商品名" Width="200">
@@ -110,10 +110,11 @@
             <TextBlock Text="{Binding DownloadFolderPath}" Width="200" TextWrapping="Wrap"/>
             <Button Content="📂選択" Width="80" Margin="5" Click="SelectDownloadFolder"/>
             <Button Content="📂開く" Width="80" Margin="5" Click="OpenDownloadFolder"/>
+            <Button Content="✏️ 編集" Width="80" Margin="5" Click="OpenEditWindow"/>
 
             <Button Content="⬇️ ダウンロード開始" Width="120" Margin="5" Click="StartDownload"/>
             <Button Content="⏸ 停止" Width="80" Margin="5" Click="StopDownload"/>
-            <Button Content="🔄 更新" Width="80" Margin="5"/>
+            <Button Content="🔄 更新" Width="80" Margin="5" Click="RefreshStatus"/>
             <CheckBox Content="🌙 ダークモード" Margin="5" IsChecked="{Binding IsDarkMode}"/>
             <!-- 進捗バーを横幅いっぱいに配置 -->
             <ProgressBar x:Name="DownloadProgress" Height="20" Margin="20,0,10,0" VerticalAlignment="Center"


### PR DESCRIPTION
## Summary
- persist user settings with `SettingsManager`
- store download history in SQLite
- open edit window from the main UI
- add Refresh button to recheck download status
- minor XAML tweaks to enable editing

## Testing
- `dotnet build BoothDownloadApp.sln` *(fails: workloads missing)*
- `dotnet build BoothDownloadApp/BoothDownloadApp.csproj` *(fails: WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840e41f20d4832da76466898cecdcad