### PR TITLE
Add retry and history features

### DIFF
--- a/BoothDownloadApp.Core/DatabaseManager.cs
+++ b/BoothDownloadApp.Core/DatabaseManager.cs
@@ -46,5 +46,22 @@
             insert.Parameters.AddWithValue("@url", url);
             insert.ExecuteNonQuery();
         }
+
+        public List<DownloadItem> LoadHistory()
+        {
+            var history = new List<DownloadItem>();
+            using var connection = new SQLiteConnection($"Data Source={_dbPath};Version=3;");
+            connection.Open();
+            using var command = new SQLiteCommand("CREATE TABLE IF NOT EXISTS History (Id INTEGER PRIMARY KEY, Name TEXT, URL TEXT);", connection);
+            command.ExecuteNonQuery();
+
+            using var select = new SQLiteCommand("SELECT Name, URL FROM History ORDER BY Id DESC;", connection);
+            using SQLiteDataReader reader = select.ExecuteReader();
+            while (reader.Read())
+            {
+                history.Add(new DownloadItem(reader.GetString(0), reader.GetString(1)));
+            }
+            return history;
+        }
     }
 }

--- a/BoothDownloadApp.Core/FilterManager.cs
+++ b/BoothDownloadApp.Core/FilterManager.cs
@@ -1,4 +1,6 @@
-﻿namespace BoothDownloadApp
+using System.Linq;
+
+namespace BoothDownloadApp
 {
     public class FilterManager
     {


### PR DESCRIPTION
## Summary
- add LINQ import in `FilterManager`
- add history loading capability to `DatabaseManager`
- add retry logic to downloads using `Settings.RetryCount`
- require `System.Threading.Tasks` in `MainWindow`

## Testing
- `dotnet build BoothDownloadApp.Core/BoothDownloadApp.Core.csproj -c Release`
- `dotnet build BoothDownloadApp/BoothDownloadApp.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e6f6f790832d92f9a2da63e1a228