### PR TITLE
Add tag scraping and database storage

### DIFF
--- a/BoothDownloadApp.Core/BoothItem.cs
+++ b/BoothDownloadApp.Core/BoothItem.cs
@@ -23,6 +23,9 @@ namespace BoothDownloadApp
         [JsonPropertyName("downloads")]
         public List<DownloadInfo> Downloads { get; set; } = new List<DownloadInfo>();
 
+        [JsonPropertyName("tags")]
+        public List<string> Tags { get; set; } = new List<string>();
+
         public bool IsSelected
         {
             get => _isSelected;

--- a/BoothDownloadApp.Core/DatabaseManager.cs
+++ b/BoothDownloadApp.Core/DatabaseManager.cs
@@ -10,28 +10,62 @@
 
         public DatabaseManager(string dbPath)
         {
-            this._dbPath = dbPath;
+            _dbPath = dbPath;
             if (!File.Exists(dbPath))
             {
                 SQLiteConnection.CreateFile(dbPath);
             }
+
+            using var connection = new SQLiteConnection($"Data Source={_dbPath};Version=3;");
+            connection.Open();
+            using var cmd = new SQLiteCommand(connection);
+            cmd.CommandText = @"CREATE TABLE IF NOT EXISTS History (Id INTEGER PRIMARY KEY, Name TEXT, URL TEXT UNIQUE);
+CREATE TABLE IF NOT EXISTS Tags (Id INTEGER PRIMARY KEY, Name TEXT UNIQUE);
+CREATE TABLE IF NOT EXISTS ItemTags (ItemId INTEGER, TagId INTEGER, UNIQUE(ItemId,TagId));";
+            cmd.ExecuteNonQuery();
         }
 
         public void SaveHistory(List<DownloadItem> items)
         {
-            using (var connection = new SQLiteConnection($"Data Source={_dbPath};Version=3;"))
+            using var connection = new SQLiteConnection($"Data Source={_dbPath};Version=3;");
+            connection.Open();
+            foreach (var item in items)
             {
-                connection.Open();
-                using var command = new SQLiteCommand("CREATE TABLE IF NOT EXISTS History (Id INTEGER PRIMARY KEY, Name TEXT, URL TEXT);", connection);
-                command.ExecuteNonQuery();
+                SaveItemWithTags(item.Name, item.URL, item.Tags, connection);
+            }
+        }
 
-                foreach (var item in items)
-                {
-                    using var insert = new SQLiteCommand("INSERT INTO History (Name, URL) VALUES (@name, @url);", connection);
-                    insert.Parameters.AddWithValue("@name", item.Name);
-                    insert.Parameters.AddWithValue("@url", item.URL);
-                    insert.ExecuteNonQuery();
-                }
+        private static long EnsureTag(string tag, SQLiteConnection connection)
+        {
+            using var insert = new SQLiteCommand("INSERT OR IGNORE INTO Tags (Name) VALUES (@name);", connection);
+            insert.Parameters.AddWithValue("@name", tag);
+            insert.ExecuteNonQuery();
+            using var select = new SQLiteCommand("SELECT Id FROM Tags WHERE Name=@name;", connection);
+            select.Parameters.AddWithValue("@name", tag);
+            return (long)select.ExecuteScalar();
+        }
+
+        private static long EnsureItem(string name, string url, SQLiteConnection connection)
+        {
+            using var insert = new SQLiteCommand("INSERT OR IGNORE INTO History (Name, URL) VALUES (@name, @url);", connection);
+            insert.Parameters.AddWithValue("@name", name);
+            insert.Parameters.AddWithValue("@url", url);
+            insert.ExecuteNonQuery();
+            using var select = new SQLiteCommand("SELECT Id FROM History WHERE URL=@url;", connection);
+            select.Parameters.AddWithValue("@url", url);
+            return (long)select.ExecuteScalar();
+        }
+
+        private static void SaveItemWithTags(string name, string url, List<string> tags, SQLiteConnection connection)
+        {
+            var itemId = EnsureItem(name, url, connection);
+            foreach (var tag in tags)
+            {
+                var tagId = EnsureTag(tag, connection);
+                using var rel = new SQLiteCommand("INSERT OR IGNORE INTO ItemTags (ItemId, TagId) VALUES (@i,@t);", connection);
+                rel.Parameters.AddWithValue("@i", itemId);
+                rel.Parameters.AddWithValue("@t", tagId);
+                rel.ExecuteNonQuery();
             }
         }
 
@@ -39,12 +73,7 @@
         {
             using var connection = new SQLiteConnection($"Data Source={_dbPath};Version=3;");
             connection.Open();
-            using var command = new SQLiteCommand("CREATE TABLE IF NOT EXISTS History (Id INTEGER PRIMARY KEY, Name TEXT, URL TEXT);", connection);
-            command.ExecuteNonQuery();
-            using var insert = new SQLiteCommand("INSERT INTO History (Name, URL) VALUES (@name, @url);", connection);
-            insert.Parameters.AddWithValue("@name", name);
-            insert.Parameters.AddWithValue("@url", url);
-            insert.ExecuteNonQuery();
+            SaveItemWithTags(name, url, new List<string>(), connection);
         }
 
         public List<DownloadItem> LoadHistory()
@@ -52,16 +81,47 @@
             var history = new List<DownloadItem>();
             using var connection = new SQLiteConnection($"Data Source={_dbPath};Version=3;");
             connection.Open();
-            using var command = new SQLiteCommand("CREATE TABLE IF NOT EXISTS History (Id INTEGER PRIMARY KEY, Name TEXT, URL TEXT);", connection);
+            using var command = new SQLiteCommand("CREATE TABLE IF NOT EXISTS History (Id INTEGER PRIMARY KEY, Name TEXT, URL TEXT UNIQUE);", connection);
             command.ExecuteNonQuery();
 
-            using var select = new SQLiteCommand("SELECT Name, URL FROM History ORDER BY Id DESC;", connection);
+            using var select = new SQLiteCommand("SELECT Id, Name, URL FROM History ORDER BY Id DESC;", connection);
             using SQLiteDataReader reader = select.ExecuteReader();
             while (reader.Read())
             {
-                history.Add(new DownloadItem(reader.GetString(0), reader.GetString(1)));
+                var id = reader.GetInt64(0);
+                var name = reader.GetString(1);
+                var url = reader.GetString(2);
+                var tags = GetTagsForItem(id, connection);
+                history.Add(new DownloadItem(name, url) { Tags = tags });
             }
             return history;
+        }
+
+        private static List<string> GetTagsForItem(long itemId, SQLiteConnection connection)
+        {
+            using var cmd = new SQLiteCommand("SELECT Name FROM Tags t JOIN ItemTags it ON t.Id = it.TagId WHERE it.ItemId=@id;", connection);
+            cmd.Parameters.AddWithValue("@id", itemId);
+            using var reader = cmd.ExecuteReader();
+            var tags = new List<string>();
+            while (reader.Read())
+            {
+                tags.Add(reader.GetString(0));
+            }
+            return tags;
+        }
+
+        public List<string> LoadAllTags()
+        {
+            var tags = new List<string>();
+            using var connection = new SQLiteConnection($"Data Source={_dbPath};Version=3;");
+            connection.Open();
+            using var cmd = new SQLiteCommand("SELECT Name FROM Tags ORDER BY Name;", connection);
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                tags.Add(reader.GetString(0));
+            }
+            return tags;
         }
     }
 }

--- a/BoothDownloadApp.Core/DownloadItem.cs
+++ b/BoothDownloadApp.Core/DownloadItem.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
 namespace BoothDownloadApp
 {
     public class DownloadItem
     {
         public string Name { get; set; }
         public string URL { get; set; }  // これを追加
+        public List<string> Tags { get; set; } = new List<string>();
 
         public DownloadItem(string name, string url)
         {


### PR DESCRIPTION
## Summary
- extend Chrome extension to scrape product tags
- store tags in BoothItem objects
- create tag tables and item/tag relationship in `DatabaseManager`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f16e4270832d87b8387674e0c3c6