### PR TITLE
Add gift handling and filtering improvements

### DIFF
--- a/BoothDownloadApp.Core/BoothLibrary.cs
+++ b/BoothDownloadApp.Core/BoothLibrary.cs
@@ -7,5 +7,8 @@ namespace BoothDownloadApp
     {
         [JsonPropertyName("library")]
         public List<BoothItem> Library { get; set; } = new List<BoothItem>();
+
+        [JsonPropertyName("gifts")]
+        public List<BoothItem> Gifts { get; set; } = new List<BoothItem>();
     }
 }

--- a/BoothDownloadApp.Core/FilterManager.cs
+++ b/BoothDownloadApp.Core/FilterManager.cs
@@ -1,12 +1,41 @@
+using System.Collections.Generic;
 using System.Linq;
 
 namespace BoothDownloadApp
 {
-    public class FilterManager
+    /// <summary>
+    /// Provides helper methods for filtering Booth items.
+    /// </summary>
+    public static class FilterManager
     {
-        public static List<DownloadItem> ApplyFilters(List<DownloadItem> items, string filter)
+        public static bool Matches(BoothItem item, bool showOnlyNotDownloaded, string? tag, bool showOnlyUpdates)
         {
-            return items.Where(item => item.Name.Contains(filter)).ToList();
+            if (showOnlyNotDownloaded && item.IsDownloaded)
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(tag) && tag != "All" && !item.Tags.Contains(tag))
+            {
+                return false;
+            }
+
+            if (showOnlyUpdates)
+            {
+                bool hasNew = item.Downloads.Any(d => !d.IsDownloaded);
+                bool hasOld = item.Downloads.Any(d => d.IsDownloaded);
+                if (!(hasNew && hasOld))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static IEnumerable<BoothItem> Apply(IEnumerable<BoothItem> items, bool showOnlyNotDownloaded, string? tag, bool showOnlyUpdates)
+        {
+            return items.Where(i => Matches(i, showOnlyNotDownloaded, tag, showOnlyUpdates));
         }
     }
 }

--- a/BoothDownloadApp.Core/Settings.cs
+++ b/BoothDownloadApp.Core/Settings.cs
@@ -2,7 +2,6 @@
 {
     public class Settings
     {
-        public bool AutoLogin { get; set; }
         public bool DarkMode { get; set; }
         public string DownloadPath { get; set; } = string.Empty;
         public int RetryCount { get; set; }

--- a/BoothDownloadApp.Maui/MainPage.xaml.cs
+++ b/BoothDownloadApp.Maui/MainPage.xaml.cs
@@ -38,12 +38,22 @@ namespace BoothDownloadApp.Maui
                 {
                     using var stream = await result.OpenReadAsync();
                     var library = await JsonSerializer.DeserializeAsync<BoothLibrary>(stream, JsonOptions);
-                    if (library?.Library != null)
+                    if (library != null)
                     {
                         Items.Clear();
-                        foreach (var item in library.Library)
+                        if (library.Library != null)
                         {
-                            Items.Add(item);
+                            foreach (var item in library.Library)
+                            {
+                                Items.Add(item);
+                            }
+                        }
+                        if (library.Gifts != null)
+                        {
+                            foreach (var item in library.Gifts)
+                            {
+                                Items.Add(item);
+                            }
                         }
                     }
                 }

--- a/BoothDownloadApp/MainWindow.xaml
+++ b/BoothDownloadApp/MainWindow.xaml
@@ -29,11 +29,14 @@
             <!-- フィルター領域 -->
             <StackPanel Grid.Column="0" Margin="5">
                 <TextBlock Text="フィルター" FontWeight="Bold" Margin="0,0,0,10"/>
-                <CheckBox Content="タグ" Margin="0,0,0,5" IsEnabled="False"/>
+                <ComboBox Width="150" Margin="0,0,0,5" ItemsSource="{Binding AvailableTags}"
+                          SelectedItem="{Binding SelectedTag}"/>
                 <CheckBox Content="未DLアイテム" Margin="0,0,0,5"
                           IsChecked="{Binding ShowOnlyNotDownloaded}"
                           Checked="FilterChanged" Unchecked="FilterChanged"/>
-                <CheckBox Content="更新あり" Margin="0,0,0,5" IsEnabled="False"/>
+                <CheckBox Content="更新あり" Margin="0,0,0,5"
+                          IsChecked="{Binding ShowOnlyUpdates}"
+                          Checked="FilterChanged" Unchecked="FilterChanged"/>
             </StackPanel>
 
             <!-- アイテム一覧領域 -->

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ The resulting executable will be under `BoothDownloadApp/bin/Debug/net8.0-window
 2. Click **"📥 JSON 読み込み"** to import `booth_data.json`. The app looks for this file in your `Downloads` folder and copies it to `C:\BoothData`.
 3. Choose a download folder with **"📂選択"** and start downloading with **"⬇️ ダウンロード開始"**. Use **"⏸ 停止"** to cancel.
 4. Downloaded files are organized under the selected folder by shop and product name. The app keeps management data in `booth_manage.json` next to the executable.
+5. Use the filter panel to narrow items by tag, hide downloaded items or show only those with updates.
 
 ## Chrome Extension Usage
 
 1. Open `chrome://extensions`, enable **Developer mode**, and choose **Load unpacked**. Select the `booth-scraper-extension` directory.
 2. While logged in to Booth, visit `https://booth.pm/library`.
 3. Click the extension icon. It scrapes all pages of your library and gifts and downloads `booth_library.json`.
-4. Move or rename this file to `booth_data.json` in your `Downloads` folder so the WPF app can load it.
+4. Move or rename this file to `booth_data.json` in your `Downloads` folder so the WPF app can load it. Gift entries are also imported.
 


### PR DESCRIPTION
## Summary
- remove unused `AutoLogin` setting
- add `Gifts` list to `BoothLibrary`
- load gifts in MAUI and WPF apps
- implement tag/update filters using new `FilterManager`
- document filtering and gift import in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f4cf9678832dbe6ac60227001924