### PR TITLE
Remove icon from notifications

### DIFF
--- a/booth-scraper-extension/background.js
+++ b/booth-scraper-extension/background.js
@@ -1,9 +1,13 @@
+const transparentIcon =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
+
 chrome.action.onClicked.addListener((tab) => {
   if (tab.id) {
     chrome.tabs.sendMessage(tab.id, { action: 'start-scrape' }, () => {
       if (chrome.runtime.lastError) {
         chrome.notifications.create({
           type: 'basic',
+          iconUrl: transparentIcon,
           title: 'Booth Scraper Error',
           message: 'Please open https://booth.pm/library before starting.'
         });
@@ -20,12 +24,14 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
     if (msg.type === 'complete') {
       chrome.notifications.create({
         type: 'basic',
+        iconUrl: transparentIcon,
         title: 'Booth Scraper',
         message: 'Scraping completed successfully.'
       });
     } else if (msg.type === 'error') {
       chrome.notifications.create({
         type: 'basic',
+        iconUrl: transparentIcon,
         title: 'Booth Scraper Error',
         message: msg.message || 'An error occurred during scraping.'
       });


### PR DESCRIPTION
## Summary
- stop using an icon file for Chrome notifications
- include transparent data URI so `iconUrl` requirement is still satisfied
- fix `manifest.json` after removing `icons`

## Testing
- `dotnet test BoothDownloadApp.sln` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68411e43fcf4832d9eebaac3920e675f