### PR TITLE
Update extension for accounts domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ The resulting executable will be under `BoothDownloadApp/bin/Debug/net8.0-window
 ## Chrome Extension Usage
 
 1. Open `chrome://extensions`, enable **Developer mode**, and choose **Load unpacked**. Select the `booth-scraper-extension` directory.
-2. While logged in to Booth, visit `https://booth.pm/library`.
+2. While logged in to Booth, visit your library page
+   (`https://accounts.booth.pm/library` or `https://booth.pm/library`).
 3. Click the extension icon. It scrapes all pages of your library and gifts and downloads `booth_library.json`.
 4. Move or rename this file to `booth_data.json` in your `Downloads` folder so the WPF app can load it. Gift entries are also imported.
 

--- a/booth-scraper-extension/README.md
+++ b/booth-scraper-extension/README.md
@@ -6,7 +6,8 @@ all purchase and gift information to a JSON file.
 ## Usage
 1. Load the extension from this folder (`chrome://extensions`, enable Developer Mode,
    then "Load unpacked").
-2. Navigate to `https://booth.pm/library` while logged in.
+2. Navigate to your Booth library page after logging in
+   (`https://accounts.booth.pm/library` or `https://booth.pm/library`).
 3. Click the extension icon to start scraping. It will fetch every page of the
    library and gift sections and then download `booth_library.json`.
 

--- a/booth-scraper-extension/background.js
+++ b/booth-scraper-extension/background.js
@@ -2,16 +2,30 @@ const transparentIcon =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
 
 chrome.action.onClicked.addListener((tab) => {
-  if (tab.id) {
+  if (!tab.id || !tab.url) return;
+
+  const allowedPages = [
+    'https://accounts.booth.pm/library',
+    'https://booth.pm/library'
+  ];
+
+  if (allowedPages.some(p => tab.url.startsWith(p))) {
     chrome.tabs.sendMessage(tab.id, { action: 'start-scrape' }, () => {
       if (chrome.runtime.lastError) {
         chrome.notifications.create({
           type: 'basic',
           iconUrl: transparentIcon,
           title: 'Booth Scraper Error',
-          message: 'Please open https://booth.pm/library before starting.'
+          message: 'Please open your Booth library page after logging in.'
         });
       }
+    });
+  } else {
+    chrome.notifications.create({
+      type: 'basic',
+      iconUrl: transparentIcon,
+      title: 'Booth Scraper Error',
+      message: 'Please open your Booth library page after logging in.'
     });
   }
 });

--- a/booth-scraper-extension/manifest.json
+++ b/booth-scraper-extension/manifest.json
@@ -4,7 +4,10 @@
   "version": "1.0",
   "description": "Scrape Booth library and gift pages to JSON",
   "permissions": ["activeTab", "scripting", "downloads", "notifications"],
-  "host_permissions": ["https://booth.pm/*"],
+  "host_permissions": [
+    "https://booth.pm/*",
+    "https://accounts.booth.pm/*"
+  ],
   "background": {
     "service_worker": "background.js"
   },
@@ -13,7 +16,10 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://booth.pm/*"],
+      "matches": [
+        "https://booth.pm/*",
+        "https://accounts.booth.pm/*"
+      ],
       "js": ["content.js"]
     }
   ]


### PR DESCRIPTION
## Summary
- support library page hosted on `accounts.booth.pm`
- update extension click handler to verify logged‑in library page
- include new host permissions in the manifest
- document new URL in both READMEs

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6841211bd16c832d998e0d3d02cca2f2