### PR TITLE
Remove reload instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The resulting executable will be under `BoothDownloadApp/bin/Debug/net8.0-window
    (`https://accounts.booth.pm/library` or `https://booth.pm/library`).
    You can also start the extension from the gifts page
    (`https://accounts.booth.pm/library/gifts`).
-   If you see an error about opening the page, reload the tab and try again.
+   If you see an error about opening the page, ensure you are logged in and on the correct page.
 3. Click the extension icon. It scrapes all pages of your library and gifts and downloads `booth_library.json`.
 4. Move or rename this file to `booth_data.json` in your `Downloads` folder so the WPF app can load it. Gift entries are also imported.
 

--- a/booth-scraper-extension/README.md
+++ b/booth-scraper-extension/README.md
@@ -10,7 +10,7 @@ all purchase and gift information to a JSON file.
    (`https://accounts.booth.pm/library` or `https://booth.pm/library`).
    The extension also works when started from the gifts page
    (`https://accounts.booth.pm/library/gifts`).
-   If you see an error saying to open the page, reload the tab and try again.
+   If you see an error saying to open the page, make sure you are logged in and on the correct page.
 3. Click the extension icon to start scraping. It will fetch every page of the
    library and gift sections and then download `booth_library.json`.
 

--- a/booth-scraper-extension/background.js
+++ b/booth-scraper-extension/background.js
@@ -11,7 +11,7 @@ chrome.action.onClicked.addListener((tab) => {
           type: 'basic',
           iconUrl: transparentIcon,
           title: 'Booth Scraper Error',
-          message: 'Could not start scraping. Try reloading the page.'
+          message: 'Could not start scraping. Ensure you are logged in and on the library page.'
         });
       }
     });


### PR DESCRIPTION
## Summary
- update background script message to avoid telling users to reload
- tweak extension README
- update main README

## Testing
- `dotnet build BoothDownloadApp.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68412ba564f8832d9ff94dcd997a2134