### PR TITLE
Fix tag fetching with background script

### DIFF
--- a/booth-scraper-extension/background.js
+++ b/booth-scraper-extension/background.js
@@ -36,8 +36,14 @@ chrome.action.onClicked.addListener((tab) => {
   });
 });
 
-chrome.runtime.onMessage.addListener((msg, sender) => {
-  if (msg.action === 'download-json') {
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.action === 'fetch-html') {
+    fetch(msg.url, { credentials: 'include' })
+      .then(r => r.text())
+      .then(text => sendResponse({ success: true, text }))
+      .catch(e => sendResponse({ success: false, error: e.message }));
+    return true;
+  } else if (msg.action === 'download-json') {
     const url = URL.createObjectURL(new Blob([msg.data], { type: 'application/json' }));
     chrome.downloads.download({ url, filename: 'booth_library.json', saveAs: true });
   } else if (msg.action === 'notify') {

--- a/booth-scraper-extension/content.js
+++ b/booth-scraper-extension/content.js
@@ -1,6 +1,16 @@
 async function fetchTags(url) {
   try {
-    const html = await fetch(url, { credentials: 'include' }).then(r => r.text());
+    const html = await new Promise((resolve, reject) => {
+      chrome.runtime.sendMessage({ action: 'fetch-html', url }, (res) => {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+        } else if (!res || !res.success) {
+          reject(new Error(res?.error || 'Failed to fetch'));
+        } else {
+          resolve(res.text);
+        }
+      });
+    });
     const doc = new DOMParser().parseFromString(html, 'text/html');
     return Array.from(doc.querySelectorAll('#js-item-tag-list a div'))
       .map(el => el.textContent.trim())


### PR DESCRIPTION
## Summary
- support cross-origin tag fetches using the extension's background script
- update content script to request HTML from the background worker

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68412e867440832da94244de8ed74509