### PR TITLE
Add product URL import feature

### DIFF
--- a/BoothDownloadApp.Core/ProductFetcher.cs
+++ b/BoothDownloadApp.Core/ProductFetcher.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace BoothDownloadApp
+{
+    public static class ProductFetcher
+    {
+        private static readonly HttpClient Client = new HttpClient();
+
+        public static async Task<BoothItem?> FetchItemAsync(string url)
+        {
+            var m = Regex.Match(url, @"items/(\d+)");
+            if (!m.Success) return null;
+            string id = m.Groups[1].Value;
+            string api = $"https://booth.pm/ja/items/{id}.json";
+            try
+            {
+                string json = await Client.GetStringAsync(api);
+                using JsonDocument doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+                var item = new BoothItem
+                {
+                    ProductName = root.GetProperty("name").GetString() ?? string.Empty,
+                    ShopName = root.GetProperty("shop").GetProperty("name").GetString() ?? string.Empty,
+                    Thumbnail = root.GetProperty("images")[0].GetProperty("resized").GetString() ?? string.Empty
+                };
+                if (root.TryGetProperty("tags", out var tags))
+                {
+                    foreach (var t in tags.EnumerateArray())
+                    {
+                        if (t.TryGetProperty("name", out var tn))
+                        {
+                            var name = tn.GetString();
+                            if (!string.IsNullOrWhiteSpace(name))
+                                item.Tags.Add(name);
+                        }
+                    }
+                }
+                if (root.TryGetProperty("variations", out var vars))
+                {
+                    foreach (var v in vars.EnumerateArray())
+                    {
+                        if (v.TryGetProperty("downloadable", out var dl) && dl.ValueKind != JsonValueKind.Null)
+                        {
+                            if (dl.TryGetProperty("no_musics", out var files))
+                                AddDownloads(item, files);
+                            if (dl.TryGetProperty("musics", out var musics))
+                                AddDownloads(item, musics);
+                        }
+                    }
+                }
+                return item;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static void AddDownloads(BoothItem item, JsonElement list)
+        {
+            foreach (var f in list.EnumerateArray())
+            {
+                string fileName = f.GetProperty("name").GetString() ?? string.Empty;
+                string link = f.GetProperty("url").GetString() ?? string.Empty;
+                item.Downloads.Add(new BoothItem.DownloadInfo { FileName = fileName, DownloadLink = link });
+            }
+        }
+    }
+}

--- a/BoothDownloadApp/MainWindow.xaml
+++ b/BoothDownloadApp/MainWindow.xaml
@@ -17,6 +17,7 @@
         <DockPanel Grid.Row="0" Margin="10">
             <TextBlock Text="Boothダウンロードアプリ" FontSize="20" FontWeight="Bold" DockPanel.Dock="Left" VerticalAlignment="Center"/>
             <Button Content="📥 JSON 読み込み" Width="120" Margin="5" DockPanel.Dock="Right" Click="LoadJsonData"/>
+            <Button Content="🌐 URL追加" Width="100" Margin="5" DockPanel.Dock="Right" Click="AddItemFromUrl"/>
         </DockPanel>
 
         <!-- 中央：フィルターとアイテム一覧 -->

--- a/BoothDownloadApp/MainWindow.xaml.cs
+++ b/BoothDownloadApp/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Data;
 using System.Windows.Controls;
+using Microsoft.VisualBasic;
 
 
 
@@ -345,6 +346,33 @@ namespace BoothDownloadApp
             catch (Exception ex)
             {
                 MessageBox.Show($"処理中にエラーが発生しました: {ex.Message}", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private async void AddItemFromUrl(object sender, RoutedEventArgs e)
+        {
+            string url = Interaction.InputBox("商品URLを入力してください", "URL入力", "");
+            if (string.IsNullOrWhiteSpace(url)) return;
+
+            try
+            {
+                var item = await ProductFetcher.FetchItemAsync(url);
+                if (item != null)
+                {
+                    Items.Add(item);
+                    SaveManagementData();
+                    UpdateDownloadStatus();
+                    ApplyFilters();
+                    MessageBox.Show("商品情報を追加しました。", "情報", MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+                else
+                {
+                    MessageBox.Show("商品情報を取得できませんでした。", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"取得に失敗しました: {ex.Message}", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 


### PR DESCRIPTION
## Summary
- support scraping a Booth product URL without needing login
- add new **URL追加** button to fetch product info

## Testing
- `dotnet build BoothDownloadApp.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414517297c832d82d55100bb6d8c74