### PR TITLE
Add manual registration screen

### DIFF
--- a/BoothDownloadApp/MainWindow.xaml
+++ b/BoothDownloadApp/MainWindow.xaml
@@ -114,6 +114,7 @@
             <Button Content="📂選択" Width="80" Margin="5" Click="SelectDownloadFolder"/>
             <Button Content="📂開く" Width="80" Margin="5" Click="OpenDownloadFolder"/>
             <Button Content="✏️ 編集" Width="80" Margin="5" Click="OpenEditWindow"/>
+            <Button Content="＋ 手動追加" Width="80" Margin="5" Click="OpenManualAdd"/>
 
             <Button Content="⬇️ ダウンロード開始" Width="120" Margin="5" Click="StartDownload"/>
             <Button Content="⏸ 停止" Width="80" Margin="5" Click="StopDownload"/>

--- a/BoothDownloadApp/MainWindow.xaml.cs
+++ b/BoothDownloadApp/MainWindow.xaml.cs
@@ -507,6 +507,31 @@ namespace BoothDownloadApp
             }
         }
 
+        private void OpenManualAdd(object sender, RoutedEventArgs e)
+        {
+            var window = new ManualAddWindow();
+            if (window.ShowDialog() == true && window.ResultItem != null)
+            {
+                var item = window.ResultItem;
+                foreach (var path in window.SelectedFilePaths)
+                {
+                    string dest = Path.Combine(DownloadFolderPath, item.ShopName, item.ProductName, Path.GetFileName(path));
+                    Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+                    try
+                    {
+                        File.Copy(path, dest, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show($"ファイルコピーに失敗しました: {ex.Message}", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
+                    }
+                }
+                Items.Add(item);
+                SaveManagementData();
+                UpdateDownloadStatus();
+            }
+        }
+
         private class RelayCommand : ICommand
         {
             private readonly Action<object?> _execute;

--- a/BoothDownloadApp/ManualAddWindow.xaml
+++ b/BoothDownloadApp/ManualAddWindow.xaml
@@ -1,0 +1,34 @@
+<Window x:Class="BoothDownloadApp.ManualAddWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="手動登録" Height="400" Width="500">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Margin="0,0,0,10">
+            <TextBlock Text="商品URL"/>
+            <TextBox x:Name="UrlTextBox" Width="400" Margin="0,0,0,5"/>
+            <Button Content="情報取得" Width="80" Click="FetchInfo_Click"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="1" Margin="0,0,0,10">
+            <TextBlock Text="商品名"/>
+            <TextBox x:Name="ProductNameTextBox" IsReadOnly="True"/>
+            <TextBlock Text="ショップ名" Margin="0,5,0,0"/>
+            <TextBox x:Name="ShopNameTextBox" IsReadOnly="True"/>
+            <TextBlock Text="タグ" Margin="0,5,0,0"/>
+            <TextBox x:Name="TagsTextBox" IsReadOnly="True"/>
+            <Button Content="ファイル追加" Width="100" Margin="0,10,0,5" Click="AddFile_Click"/>
+            <ListBox x:Name="FilesListBox" Height="100"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="登録" Width="80" Margin="5" Click="OkButton_Click"/>
+            <Button Content="キャンセル" Width="80" Margin="5" Click="CancelButton_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/BoothDownloadApp/ManualAddWindow.xaml.cs
+++ b/BoothDownloadApp/ManualAddWindow.xaml.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Windows;
+using Microsoft.Win32;
+
+namespace BoothDownloadApp
+{
+    public partial class ManualAddWindow : Window
+    {
+        private readonly List<string> _files = new();
+        public BoothItem? ResultItem { get; private set; }
+        public IReadOnlyList<string> SelectedFilePaths => _files;
+
+        public ManualAddWindow()
+        {
+            InitializeComponent();
+        }
+
+        private async void FetchInfo_Click(object sender, RoutedEventArgs e)
+        {
+            var url = UrlTextBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(url)) return;
+            try
+            {
+                var details = await FetchItemDetails(url);
+                if (details != null)
+                {
+                    ProductNameTextBox.Text = details.ProductName;
+                    ShopNameTextBox.Text = details.ShopName;
+                    TagsTextBox.Text = string.Join(", ", details.Tags);
+                }
+                else
+                {
+                    MessageBox.Show("情報を取得できませんでした。", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"情報取得に失敗しました: {ex.Message}", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private static async Task<ItemDetails?> FetchItemDetails(string url)
+        {
+            var m = Regex.Match(url, @"items/(\d+)");
+            if (!m.Success) return null;
+            string id = m.Groups[1].Value;
+            var uri = new Uri(url);
+            string api = $"{uri.Scheme}://{uri.Host}/items/{id}.json";
+            using HttpClient client = new HttpClient();
+            using var stream = await client.GetStreamAsync(api);
+            using var doc = await JsonDocument.ParseAsync(stream);
+            var root = doc.RootElement;
+            string product = root.GetProperty("name").GetString() ?? string.Empty;
+            string shop = root.GetProperty("shop").GetProperty("name").GetString() ?? string.Empty;
+            List<string> tags = new();
+            if (root.TryGetProperty("tags", out var tagElem))
+            {
+                foreach (var t in tagElem.EnumerateArray())
+                {
+                    if (t.TryGetProperty("name", out var n))
+                    {
+                        tags.Add(n.GetString() ?? string.Empty);
+                    }
+                }
+            }
+            return new ItemDetails(product, shop, tags);
+        }
+
+        private record ItemDetails(string ProductName, string ShopName, List<string> Tags);
+
+        private void AddFile_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new OpenFileDialog { Multiselect = true };
+            if (dialog.ShowDialog() == true)
+            {
+                foreach (var f in dialog.FileNames)
+                {
+                    _files.Add(f);
+                    FilesListBox.Items.Add(System.IO.Path.GetFileName(f));
+                }
+            }
+        }
+
+        private void OkButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(ProductNameTextBox.Text) || string.IsNullOrWhiteSpace(ShopNameTextBox.Text))
+            {
+                MessageBox.Show("情報を取得してください。", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
+            ResultItem = new BoothItem
+            {
+                ProductName = ProductNameTextBox.Text,
+                ShopName = ShopNameTextBox.Text,
+                Tags = TagsTextBox.Text.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(t => t.Trim()).ToList(),
+                Downloads = _files.Select(f => new BoothItem.DownloadInfo
+                {
+                    FileName = System.IO.Path.GetFileName(f),
+                    DownloadLink = string.Empty,
+                    IsDownloaded = true
+                }).ToList(),
+                IsDownloaded = true
+            };
+
+            DialogResult = true;
+            Close();
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow manual addition of items from MainWindow
- create ManualAddWindow to fetch product info from Booth and register local files

## Testing
- `dotnet build BoothDownloadApp/BoothDownloadApp.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841448e0bc8832dbc4cdc10d9d39a3e