### PR TITLE
Fix base URL for scraper extension

### DIFF
--- a/booth-scraper-extension/content.js
+++ b/booth-scraper-extension/content.js
@@ -1,6 +1,8 @@
 (async () => {
   const sleep = ms => new Promise(res => setTimeout(res, ms));
-  const base = "https://booth.pm";
+  // Use the current page's origin so the script works on both
+  // https://booth.pm and https://accounts.booth.pm
+  const base = location.origin;
 
   const updateProgress = (text, value, max) => {
     const progress = document.getElementById("progress");


### PR DESCRIPTION
## Summary
- use `location.origin` in scraper to support both `booth.pm` and `accounts.booth.pm`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684904efbb20832d885d820f5d8a2636