### PR TITLE
Enable auto fetch on manual item URL

### DIFF
--- a/BoothDownloadApp/ManualAddWindow.xaml
+++ b/BoothDownloadApp/ManualAddWindow.xaml
@@ -11,17 +11,17 @@
 
         <StackPanel Grid.Row="0" Margin="0,0,0,10">
             <TextBlock Text="商品URL"/>
-            <TextBox x:Name="UrlTextBox" Width="400" Margin="0,0,0,5"/>
+            <TextBox x:Name="UrlTextBox" Width="400" Margin="0,0,0,5" TextChanged="UrlTextBox_TextChanged"/>
             <Button Content="情報取得" Width="80" Click="FetchInfo_Click"/>
         </StackPanel>
 
         <StackPanel Grid.Row="1" Margin="0,0,0,10">
             <TextBlock Text="商品名"/>
-            <TextBox x:Name="ProductNameTextBox" IsReadOnly="True"/>
+            <TextBox x:Name="ProductNameTextBox" />
             <TextBlock Text="ショップ名" Margin="0,5,0,0"/>
-            <TextBox x:Name="ShopNameTextBox" IsReadOnly="True"/>
+            <TextBox x:Name="ShopNameTextBox" />
             <TextBlock Text="タグ" Margin="0,5,0,0"/>
-            <TextBox x:Name="TagsTextBox" IsReadOnly="True"/>
+            <TextBox x:Name="TagsTextBox" />
             <Button Content="ファイル追加" Width="100" Margin="0,10,0,5" Click="AddFile_Click"/>
             <ListBox x:Name="FilesListBox" Height="100"/>
         </StackPanel>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The resulting executable will be under `BoothDownloadApp/bin/Debug/net8.0-window
 3. Choose a download folder with **"📂選択"** and start downloading with **"⬇️ ダウンロード開始"**. Use **"⏸ 停止"** to cancel.
 4. Downloaded files are organized under the selected folder by shop and product name. The app keeps management data in `booth_manage.json` next to the executable.
 5. Use the filter panel to narrow items by tag, hide downloaded items or show only those with updates.
+6. Use **"＋ 手動追加"** to register items yourself. Pasting a product URL automatically fetches the name, shop and tags. You can still press **"情報取得"** to retry or type details manually. Local files may be attached and copied into your download folder.
+7. To quickly add an item by URL without providing files, click **"🌐 URL追加"** and enter the product link. The app fetches download information automatically.
 
 ## Chrome Extension Usage
 


### PR DESCRIPTION
## Summary
- automatically load item details in manual add when a URL is pasted
- allow repeated fetching via the existing button
- document this auto-fetch behavior in the README
- cancel pending fetch task if manual add window is closed

## Testing
- `dotnet build BoothDownloadApp.sln -nologo` *(fails: missing workloads)*
- `dotnet build BoothDownloadApp/BoothDownloadApp.csproj -nologo` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849171df39c832d9434921091c92320