### PR TITLE
Allow choosing JSON file

### DIFF
--- a/BoothDownloadApp/MainWindow.xaml.cs
+++ b/BoothDownloadApp/MainWindow.xaml.cs
@@ -293,51 +293,47 @@ namespace BoothDownloadApp
 
         private void LoadJsonData(object sender, RoutedEventArgs e)
         {
-            string sourcePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads", "booth_data.json");
-            string targetDirectory = "C:\\BoothData";
-            string targetPath = Path.Combine(targetDirectory, "booth_data.json");
+            var dialog = new OpenFileDialog
+            {
+                Filter = "JSON Files (*.json)|*.json|All Files (*.*)|*.*",
+                Title = "booth_data.json を選択してください"
+            };
+
+            if (dialog.ShowDialog() != true)
+            {
+                return;
+            }
 
             try
             {
-                if (File.Exists(sourcePath))
+                string json = File.ReadAllText(dialog.FileName);
+                var boothLibrary = JsonSerializer.Deserialize<BoothLibrary>(json, JsonSerializerOptions);
+
+                if (boothLibrary != null)
                 {
-                    if (!Directory.Exists(targetDirectory))
+                    Items.Clear();
+                    if (boothLibrary.Library != null)
                     {
-                        Directory.CreateDirectory(targetDirectory);
+                        foreach (var item in boothLibrary.Library)
+                        {
+                            Items.Add(item);
+                        }
                     }
-                    File.Copy(sourcePath, targetPath, true);
+                    if (boothLibrary.Gifts != null)
+                    {
+                        foreach (var item in boothLibrary.Gifts)
+                        {
+                            Items.Add(item);
+                        }
+                    }
+                    UpdateDownloadStatus();
+                    ApplyFilters();
                 }
 
-                if (File.Exists(targetPath))
-                {
-                    string json = File.ReadAllText(targetPath);
-                    var boothLibrary = JsonSerializer.Deserialize<BoothLibrary>(json, JsonSerializerOptions);
+                MessageBox.Show("JSON データを読み込みました！", "情報", MessageBoxButton.OK, MessageBoxImage.Information);
 
-                    if (boothLibrary != null)
-                    {
-                        Items.Clear();
-                        if (boothLibrary.Library != null)
-                        {
-                            foreach (var item in boothLibrary.Library)
-                            {
-                                Items.Add(item);
-                            }
-                        }
-                        if (boothLibrary.Gifts != null)
-                        {
-                            foreach (var item in boothLibrary.Gifts)
-                            {
-                                Items.Add(item);
-                            }
-                        }
-                        UpdateDownloadStatus();
-                        ApplyFilters();
-                    }
-                    MessageBox.Show("JSON データを読み込みました！", "情報", MessageBoxButton.OK, MessageBoxImage.Information);
-
-                    // 読み込み後、管理用JSONに保存して内容を反映
-                    SaveManagementData();
-                }
+                // 読み込み後、管理用JSONに保存して内容を反映
+                SaveManagementData();
             }
             catch (JsonException ex)
             {

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The resulting executable will be under `BoothDownloadApp/bin/Debug/net8.0-window
 ## WPF Application Usage
 
 1. Launch `BoothDownloadApp.exe` from the build output or run `dotnet run --project BoothDownloadApp/BoothDownloadApp.csproj`.
-2. Click **"📥 JSON 読み込み"** to import `booth_data.json`. The app looks for this file in your `Downloads` folder and copies it to `C:\BoothData`.
+2. Click **"📥 JSON 読み込み"** and choose your `booth_data.json` file.
 3. Choose a download folder with **"📂選択"** and start downloading with **"⬇️ ダウンロード開始"**. Use **"⏸ 停止"** to cancel.
 4. Downloaded files are organized under the selected folder by shop and product name. The app keeps management data in `booth_manage.json` next to the executable.
 5. Use the filter panel to narrow items by tag, hide downloaded items or show only those with updates.
@@ -36,5 +36,5 @@ The resulting executable will be under `BoothDownloadApp/bin/Debug/net8.0-window
    (`https://accounts.booth.pm/library/gifts`).
    If you see an error about opening the page, ensure you are logged in and on the correct page.
 3. Click the extension icon. It scrapes all pages of your library and gifts and downloads `booth_library.json`.
-4. Move or rename this file to `booth_data.json` in your `Downloads` folder so the WPF app can load it. Gift entries are also imported.
+4. Use the **"📥 JSON 読み込み"** button in the WPF app to select the downloaded file. Gift entries are also imported.
 


### PR DESCRIPTION
## Summary
- open a file selection dialog when importing JSON
- document that the app prompts for `booth_data.json`

## Testing
- `dotnet build BoothDownloadApp.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68496b739d50832da39dada7fbc9fe45