### PR TITLE
Fix Booth tag scraping across subdomains

### DIFF
--- a/booth-scraper-extension/README.md
+++ b/booth-scraper-extension/README.md
@@ -16,7 +16,9 @@ all purchase and gift information to a JSON file.
    Item tags are now fetched concurrently for faster completion. The scraping
    logic lives in `scraper.js` which keeps the injected `content.js` minimal.
    The scripts are injected into the main page context so that tag fetching
-   can reuse your logged in session cookies without CORS errors.
+   can reuse your logged in session cookies without CORS errors. Tag requests
+   are always sent to `https://booth.pm` even when a shop uses its own
+   subdomain so that all product tags are retrieved correctly.
 
 The produced JSON file contains two arrays:
 

--- a/booth-scraper-extension/scraper.js
+++ b/booth-scraper-extension/scraper.js
@@ -66,7 +66,7 @@
           const pathMatch = url.pathname.match(/^\/(?:([a-z]{2})\/)?items\/(\d+)/);
           if (!pathMatch) continue;
           const lang = pathMatch[1] || 'ja';
-          const apiUrl = `${url.origin}/${lang}/items/${pathMatch[2]}.json`;
+          const apiUrl = `https://booth.pm/${lang}/items/${pathMatch[2]}.json`;
           const res = await fetch(apiUrl);
           const json = await res.json();
           if (Array.isArray(json.tags)) {


### PR DESCRIPTION
## Summary
- ensure the extension fetches tag JSON from the main domain
- document tag request behaviour in the extension README

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68496f178698832dacd14a2e64a51452