### PR TITLE
Fix scraping domain and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The resulting executable will be under `BoothDownloadApp/bin/Debug/net8.0-window
 ## Chrome Extension Usage
 
 1. Open `chrome://extensions`, enable **Developer mode**, and choose **Load unpacked**. Select the `booth-scraper-extension` directory.
-2. While logged in to Booth, visit your library page
-   (`https://accounts.booth.pm/library` or `https://booth.pm/library`).
+2. While logged in to Booth, open your library page
+   (usually `https://accounts.booth.pm/library`).
    You can also start the extension from the gifts page
    (`https://accounts.booth.pm/library/gifts`).
    If you see an error about opening the page, ensure you are logged in and on the correct page.

--- a/booth-scraper-extension/README.md
+++ b/booth-scraper-extension/README.md
@@ -7,7 +7,7 @@ all purchase and gift information to a JSON file.
 1. Load the extension from this folder (`chrome://extensions`, enable Developer Mode,
    then "Load unpacked").
 2. Navigate to your Booth library page after logging in
-   (`https://accounts.booth.pm/library` or `https://booth.pm/library`).
+   (usually `https://accounts.booth.pm/library`).
    The extension also works when started from the gifts page
    (`https://accounts.booth.pm/library/gifts`).
    If you see an error saying to open the page, make sure you are logged in and on the correct page.

--- a/booth-scraper-extension/scraper.js
+++ b/booth-scraper-extension/scraper.js
@@ -1,6 +1,8 @@
 (() => {
   const sleep = ms => new Promise(res => setTimeout(res, ms));
-  const base = 'https://booth.pm';
+  // Use the current page's origin so the scraper works on
+  // both https://accounts.booth.pm and https://booth.pm
+  const base = location.origin;
 
   const fetchHtml = async url =>
     new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- use the current page origin when scraping so the extension works on `accounts.booth.pm`
- clarify README instructions that the library page is usually served from `https://accounts.booth.pm`

## Testing
- `dotnet build BoothDownloadApp.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849763341b0832db8612bee743a68b5