### PR TITLE
Fix extension background script config

### DIFF
--- a/booth-scraper-extension/manifest.json
+++ b/booth-scraper-extension/manifest.json
@@ -3,7 +3,14 @@
   "name": "Booth Library Scraper",
   "version": "1.0",
   "description": "Boothの購入商品・ギフト情報を取得してJSONで保存",
-  "permissions": ["scripting", "activeTab"],
+  "permissions": [
+    "scripting",
+    "activeTab",
+    "downloads"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
   "action": {
     "default_popup": "popup.html"
   },


### PR DESCRIPTION
## Summary
- add missing `downloads` permission
- register `background.js` as a service worker

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('booth-scraper-extension/manifest.json','utf8')); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_684978c59380832d934c58c6cb1edb72