### PR TITLE
Restore repo to PR #31 state

### DIFF
--- a/BoothDownloadApp/ManualAddWindow.xaml.cs
+++ b/BoothDownloadApp/ManualAddWindow.xaml.cs
@@ -82,9 +82,8 @@ namespace BoothDownloadApp
             var m = Regex.Match(url, @"items/(\d+)");
             if (!m.Success) return null;
             string id = m.Groups[1].Value;
-            var langMatch = Regex.Match(url, @"/([a-z]{2})/items/");
-            string lang = langMatch.Success ? langMatch.Groups[1].Value : "ja";
-            string api = $"https://booth.pm/{lang}/items/{id}.json";
+            var uri = new Uri(url);
+            string api = $"{uri.Scheme}://{uri.Host}/items/{id}.json";
             using HttpClient client = new HttpClient();
             using var stream = await client.GetStreamAsync(api);
             using var doc = await JsonDocument.ParseAsync(stream);

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The resulting executable will be under `BoothDownloadApp/bin/Debug/net8.0-window
 ## Chrome Extension Usage
 
 1. Open `chrome://extensions`, enable **Developer mode**, and choose **Load unpacked**. Select the `booth-scraper-extension` directory.
-2. While logged in to Booth, open your library page
-   (usually `https://accounts.booth.pm/library`).
+2. While logged in to Booth, visit your library page
+   (`https://accounts.booth.pm/library` or `https://booth.pm/library`).
    You can also start the extension from the gifts page
    (`https://accounts.booth.pm/library/gifts`).
    If you see an error about opening the page, ensure you are logged in and on the correct page.

--- a/booth-scraper-extension/README.md
+++ b/booth-scraper-extension/README.md
@@ -7,17 +7,16 @@ all purchase and gift information to a JSON file.
 1. Load the extension from this folder (`chrome://extensions`, enable Developer Mode,
    then "Load unpacked").
 2. Navigate to your Booth library page after logging in
-   (usually `https://accounts.booth.pm/library`).
+   (`https://accounts.booth.pm/library` or `https://booth.pm/library`).
    The extension also works when started from the gifts page
    (`https://accounts.booth.pm/library/gifts`).
    If you see an error saying to open the page, make sure you are logged in and on the correct page.
 3. Click the extension icon to start scraping. It will fetch every page of the
    library and gift sections and then download `booth_library.json`.
-   Item tags are fetched concurrently for faster completion. The scraping
+   Item tags are now fetched concurrently for faster completion. The scraping
    logic lives in `scraper.js` which keeps the injected `content.js` minimal.
-   The scripts are injected into the main page context so tag fetching can reuse
-   your logged in session cookies without CORS errors. Each item's details are
-   requested from its own domain so tags load correctly regardless of subdomain.
+   The scripts are injected into the main page context so that tag fetching
+   can reuse your logged in session cookies without CORS errors.
 
 The produced JSON file contains two arrays:
 

--- a/booth-scraper-extension/manifest.json
+++ b/booth-scraper-extension/manifest.json
@@ -3,16 +3,9 @@
   "name": "Booth Library Scraper",
   "version": "1.0",
   "description": "Boothの購入商品・ギフト情報を取得してJSONで保存",
-  "permissions": [
-    "scripting",
-    "activeTab",
-    "downloads"
-  ],
-  "background": {
-    "service_worker": "background.js"
-  },
+  "permissions": ["scripting", "activeTab"],
   "action": {
     "default_popup": "popup.html"
   },
-  "host_permissions": ["https://booth.pm/*", "https://*.booth.pm/*"]
+  "host_permissions": ["https://booth.pm/*"]
 }

--- a/booth-scraper-extension/scraper.js
+++ b/booth-scraper-extension/scraper.js
@@ -1,21 +1,6 @@
 (() => {
   const sleep = ms => new Promise(res => setTimeout(res, ms));
-  // Use the current page's origin so the scraper works on
-  // both https://accounts.booth.pm and https://booth.pm
   const base = location.origin;
-
-  const fetchHtml = async url =>
-    new Promise((resolve, reject) => {
-      chrome.runtime.sendMessage({ action: 'fetch-html', url }, res => {
-        if (chrome.runtime.lastError) {
-          reject(chrome.runtime.lastError);
-        } else if (res && res.success) {
-          resolve(res.text);
-        } else {
-          reject(new Error(res?.error || 'failed to fetch html'));
-        }
-      });
-    });
 
   const updateProgress = (text, value, max) => {
     const progress = document.getElementById('progress');
@@ -57,13 +42,8 @@
     const all = [];
     while (true) {
       const url = `${base}${path}?page=${page}`;
-      let html;
-      try {
-        html = await fetchHtml(url);
-      } catch (e) {
-        console.warn('ページ取得失敗', url, e);
-        break;
-      }
+      const res = await fetch(url);
+      const html = await res.text();
       const products = extractProducts(html);
       if (products.length === 0) break;
       all.push(...products);


### PR DESCRIPTION
## Summary
- revert Chrome extension to the version from PR #31
- bring back popup UI and scraper.js
- restore README instructions for library URL
- remove language-specific item fetch logic

## Testing
- `dotnet build BoothDownloadApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497a3da6bc832da5db3a8b4d54932d