### PR TITLE
Remove unused URL add button from main UI

### DIFF
--- a/BoothDownloadApp/MainWindow.xaml
+++ b/BoothDownloadApp/MainWindow.xaml
@@ -17,7 +17,6 @@
         <DockPanel Grid.Row="0" Margin="10">
             <TextBlock Text="Boothダウンロードアプリ" FontSize="20" FontWeight="Bold" DockPanel.Dock="Left" VerticalAlignment="Center"/>
             <Button Content="📥 JSON 読み込み" Width="120" Margin="5" DockPanel.Dock="Right" Click="LoadJsonData"/>
-            <Button Content="🌐 URL追加" Width="100" Margin="5" DockPanel.Dock="Right" Click="AddItemFromUrl"/>
         </DockPanel>
 
         <!-- 中央：フィルターとアイテム一覧 -->

--- a/BoothDownloadApp/MainWindow.xaml.cs
+++ b/BoothDownloadApp/MainWindow.xaml.cs
@@ -17,7 +17,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Data;
 using System.Windows.Controls;
-using Microsoft.VisualBasic;
 
 
 
@@ -350,34 +349,6 @@ namespace BoothDownloadApp
             }
         }
 
-        private async void AddItemFromUrl(object sender, RoutedEventArgs e)
-        {
-            string url = Interaction.InputBox("商品URLを入力してください", "URL入力", "");
-            if (string.IsNullOrWhiteSpace(url)) return;
-
-            try
-            {
-                var item = await ProductFetcher.FetchItemAsync(url);
-                if (item != null)
-                {
-                    item.ItemUrl = url;
-                    item.TagsFetched = item.Tags.Count > 0;
-                    Items.Add(item);
-                    SaveManagementData();
-                    UpdateDownloadStatus();
-                    ApplyFilters();
-                    MessageBox.Show("商品情報を追加しました。", "情報", MessageBoxButton.OK, MessageBoxImage.Information);
-                }
-                else
-                {
-                    MessageBox.Show("商品情報を取得できませんでした。", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
-                }
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show($"取得に失敗しました: {ex.Message}", "エラー", MessageBoxButton.OK, MessageBoxImage.Error);
-            }
-        }
 
         #region INotifyPropertyChanged 実装
         public event PropertyChangedEventHandler? PropertyChanged;

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The resulting executable will be under `BoothDownloadApp/bin/Debug/net8.0-window
 4. Downloaded files are organized under the selected folder by shop and product name. The app keeps management data in `booth_manage.json` next to the executable.
 5. Use the filter panel to narrow items by tag, hide downloaded items or show only those with updates. A search box lets you filter by keyword across names, shops and tags.
 6. Use **"＋ 手動追加"** to register items yourself. Pasting a product URL automatically fetches the name, shop and tags. You can still press **"情報取得"** to retry or type details manually. Local files may be attached and copied into your download folder.
-7. To quickly add an item by URL without providing files, click **"🌐 URL追加"** and enter the product link. The app fetches download information automatically.
 
 ## Chrome Extension Usage
 


### PR DESCRIPTION
## Summary
- delete the `URL追加` button from the main WPF window
- remove the now-unused `AddItemFromUrl` handler
- update README usage instructions accordingly

## Testing
- `dotnet build BoothDownloadApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849926e6520832d8f9c4505405c31e1