### PR TITLE
Handle invalid directory characters

### DIFF
--- a/BoothDownloadApp.Core/Services/DownloadService.cs
+++ b/BoothDownloadApp.Core/Services/DownloadService.cs
@@ -23,9 +23,11 @@ namespace BoothDownloadApp
             foreach (var entry in fileList)
             {
                 token.ThrowIfCancellationRequested();
-                string folder = Path.Combine(rootPath, entry.item.ShopName, entry.item.ProductName);
+                string folder = Path.Combine(rootPath,
+                    PathUtils.Sanitize(entry.item.ShopName),
+                    PathUtils.Sanitize(entry.item.ProductName));
                 Directory.CreateDirectory(folder);
-                string path = Path.Combine(folder, entry.file.FileName);
+                string path = Path.Combine(folder, PathUtils.Sanitize(entry.file.FileName));
                 int attempts = 0;
                 while (true)
                 {
@@ -39,7 +41,7 @@ namespace BoothDownloadApp
                         entry.file.IsDownloaded = true;
                         downloaded++;
                         progress?.Report((int)((double)downloaded / totalFiles * 100));
-                        db.SaveHistoryItem(entry.file.FileName, entry.file.DownloadLink);
+                        db.SaveHistoryItem(PathUtils.Sanitize(entry.file.FileName), entry.file.DownloadLink);
                         break;
                     }
                     catch (OperationCanceledException)

--- a/BoothDownloadApp.Core/Utils/PathUtils.cs
+++ b/BoothDownloadApp.Core/Utils/PathUtils.cs
@@ -1,0 +1,18 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace BoothDownloadApp
+{
+    public static class PathUtils
+    {
+        /// <summary>
+        /// Remove invalid file name characters from the provided string.
+        /// </summary>
+        public static string Sanitize(string name)
+        {
+            var invalid = Path.GetInvalidFileNameChars();
+            return new string(name.Where(c => Array.IndexOf(invalid, c) == -1).ToArray());
+        }
+    }
+}

--- a/BoothDownloadApp/MainWindow.xaml.cs
+++ b/BoothDownloadApp/MainWindow.xaml.cs
@@ -425,7 +425,11 @@ namespace BoothDownloadApp
             {
                 foreach (var download in item.Downloads)
                 {
-                    string path = Path.Combine(DownloadFolderPath, item.ShopName, item.ProductName, download.FileName);
+                    string path = Path.Combine(
+                        DownloadFolderPath,
+                        PathUtils.Sanitize(item.ShopName),
+                        PathUtils.Sanitize(item.ProductName),
+                        PathUtils.Sanitize(download.FileName));
                     download.IsDownloaded = File.Exists(path);
                 }
                 item.IsDownloaded = item.Downloads.All(d => d.IsDownloaded);
@@ -549,7 +553,11 @@ namespace BoothDownloadApp
                 var item = window.ResultItem;
                 foreach (var path in window.SelectedFilePaths)
                 {
-                    string dest = Path.Combine(DownloadFolderPath, item.ShopName, item.ProductName, Path.GetFileName(path));
+                    string dest = Path.Combine(
+                        DownloadFolderPath,
+                        PathUtils.Sanitize(item.ShopName),
+                        PathUtils.Sanitize(item.ProductName),
+                        PathUtils.Sanitize(Path.GetFileName(path)));
                     Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
                     try
                     {


### PR DESCRIPTION
## Summary
- sanitize path segments to remove invalid characters
- use sanitized names when creating download folders and files

## Testing
- `dotnet build BoothDownloadApp.sln -c Release` *(fails: requires workloads)*
- `dotnet build BoothDownloadApp/BoothDownloadApp.csproj -c Release` *(fails: WindowsDesktop SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c589643ac832db1fb3483e1284078