### PR TITLE
Simplify extension progress display

### DIFF
--- a/booth-scraper-extension/popup.html
+++ b/booth-scraper-extension/popup.html
@@ -8,8 +8,7 @@
 <body>
   <h2>Booth Scraper</h2>
   <button id="start">スクレイピング開始</button>
-  <div id="progress-container">
-    <progress id="progress" value="0" max="100"></progress>
+  <div id="status-container">
     <span id="status">待機中...</span>
   </div>
   <script src="popup.js"></script>

--- a/booth-scraper-extension/popup.js
+++ b/booth-scraper-extension/popup.js
@@ -1,9 +1,7 @@
-const progress = document.getElementById('progress');
 const status = document.getElementById('status');
 
 document.getElementById('start').addEventListener('click', async () => {
-  if (progress) progress.value = 0;
-  if (status) status.textContent = 'スクレイピング中...';
+  if (status) status.textContent = '実行中...';
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   await chrome.scripting.executeScript({
     target: { tabId: tab.id },
@@ -16,11 +14,7 @@ document.getElementById('start').addEventListener('click', async () => {
 });
 
 chrome.runtime.onMessage.addListener((msg) => {
-  if (msg.action === 'progress' && progress && status) {
-    progress.max = msg.max;
-    progress.value = msg.value;
-    status.textContent = `${msg.text} (${msg.value}/${msg.max})`;
-  } else if (msg.action === 'complete' && status) {
+  if (msg.action === 'complete' && status) {
     status.textContent = '完了';
   }
 });

--- a/booth-scraper-extension/scraper.js
+++ b/booth-scraper-extension/scraper.js
@@ -2,11 +2,6 @@
   const sleep = ms => new Promise(res => setTimeout(res, ms));
   const base = location.origin;
 
-  const updateProgress = (text, value, max) => {
-    if (typeof chrome !== 'undefined' && chrome.runtime) {
-      chrome.runtime.sendMessage({ action: 'progress', text, value, max });
-    }
-  };
 
 
   const extractProducts = html => {
@@ -42,16 +37,11 @@
       const res = await fetch(url);
       const html = await res.text();
       const products = extractProducts(html);
-      if (products.length === 0) {
-        updateProgress('ページ取得中', page - 1, page - 1);
-        break;
-      }
+      if (products.length === 0) break;
       all.push(...products);
-      updateProgress('ページ取得中', page, page + 1);
       page++;
       await sleep(300);
     }
-    updateProgress('ページ取得完了', page - 1, page - 1);
     return all;
   };
 
@@ -60,7 +50,6 @@
       ...(await getAllPages('/library')),
       ...(await getAllPages('/library/gifts'))
     ];
-    updateProgress('書き出し中', 0, 1);
     return all;
   };
 

--- a/booth-scraper-extension/style.css
+++ b/booth-scraper-extension/style.css
@@ -8,11 +8,8 @@ button {
   padding: 10px;
   margin-bottom: 10px;
 }
-#progress-container {
+#status-container {
   display: flex;
   flex-direction: column;
   gap: 5px;
-}
-progress {
-  width: 100%;
 }


### PR DESCRIPTION
## Summary
- drop progress bar from popup UI
- show simple status text only
- remove page-count prefetch and per-page updates

## Testing
- `node --check booth-scraper-extension/scraper.js`
- `node --check booth-scraper-extension/popup.js`


------
https://chatgpt.com/codex/tasks/task_e_684c5961264c832da1958a1aa523da0e