### PR TITLE
Add page links and reset checkboxes after download

### DIFF
--- a/BoothDownloadApp.Core/Models/BoothItem.cs
+++ b/BoothDownloadApp.Core/Models/BoothItem.cs
@@ -23,6 +23,9 @@ namespace BoothDownloadApp
         [JsonPropertyName("itemUrl")]
         public string ItemUrl { get; set; } = string.Empty;
 
+        [JsonPropertyName("shopUrl")]
+        public string ShopUrl { get; set; } = string.Empty;
+
         [JsonPropertyName("downloads")]
         public List<DownloadInfo> Downloads { get; set; } = new List<DownloadInfo>();
 

--- a/BoothDownloadApp.Core/Services/DownloadService.cs
+++ b/BoothDownloadApp.Core/Services/DownloadService.cs
@@ -39,6 +39,7 @@ namespace BoothDownloadApp
                         await response.Content.CopyToAsync(fs, token);
 
                         entry.file.IsDownloaded = true;
+                        entry.file.IsSelected = false;
                         downloaded++;
                         progress?.Report((int)((double)downloaded / totalFiles * 100));
                         db.SaveHistoryItem(PathUtils.Sanitize(entry.file.FileName), entry.file.DownloadLink);
@@ -63,6 +64,7 @@ namespace BoothDownloadApp
             foreach (var i in items)
             {
                 i.IsDownloaded = i.Downloads.All(d => d.IsDownloaded);
+                i.IsSelected = false;
             }
         }
     }

--- a/BoothDownloadApp.Core/Services/JsonLoader.cs
+++ b/BoothDownloadApp.Core/Services/JsonLoader.cs
@@ -38,6 +38,7 @@ namespace BoothDownloadApp
                         ShopName = si.ShopName,
                         Thumbnail = si.ImageUrl,
                         ItemUrl = si.ItemUrl,
+                        ShopUrl = si.ShopUrl,
                         Downloads = si.Files.Select(f => new BoothItem.DownloadInfo
                         {
                             FileName = f.FileName,

--- a/BoothDownloadApp.Core/Services/ProductFetcher.cs
+++ b/BoothDownloadApp.Core/Services/ProductFetcher.cs
@@ -26,7 +26,9 @@ namespace BoothDownloadApp
                 {
                     ProductName = root.GetProperty("name").GetString() ?? string.Empty,
                     ShopName = root.GetProperty("shop").GetProperty("name").GetString() ?? string.Empty,
-                    Thumbnail = root.GetProperty("images")[0].GetProperty("resized").GetString() ?? string.Empty
+                    Thumbnail = root.GetProperty("images")[0].GetProperty("resized").GetString() ?? string.Empty,
+                    ItemUrl = root.GetProperty("url").GetString() ?? url,
+                    ShopUrl = root.GetProperty("shop").GetProperty("url").GetString() ?? string.Empty
                 };
                 if (root.TryGetProperty("tags", out var tags))
                 {

--- a/BoothDownloadApp/MainWindow.xaml
+++ b/BoothDownloadApp/MainWindow.xaml
@@ -54,15 +54,38 @@
                                 <DataTemplate>
                                     <StackPanel Orientation="Horizontal">
                                         <!-- 商品単位のチェックボックス -->
-                                        <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}" 
+                                        <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"
                           VerticalAlignment="Center" Margin="0,0,5,0"/>
-                                        <TextBlock Text="{Binding ProductName}" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{Binding ProductName}"
+                                                   Foreground="Blue"
+                                                   Cursor="Hand"
+                                                   VerticalAlignment="Center">
+                                            <TextBlock.InputBindings>
+                                                <MouseBinding Gesture="LeftClick"
+                                                              Command="{Binding DataContext.OpenLinkCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                              CommandParameter="{Binding ItemUrl}"/>
+                                            </TextBlock.InputBindings>
+                                        </TextBlock>
                                     </StackPanel>
                                 </DataTemplate>
                             </GridViewColumn.CellTemplate>
                         </GridViewColumn>
 
-                        <GridViewColumn Header="ショップ名" Width="150" DisplayMemberBinding="{Binding ShopName}" />
+                        <GridViewColumn Header="ショップ名" Width="150">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding ShopName}"
+                                               Foreground="Blue"
+                                               Cursor="Hand">
+                                        <TextBlock.InputBindings>
+                                            <MouseBinding Gesture="LeftClick"
+                                                          Command="{Binding DataContext.OpenLinkCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                          CommandParameter="{Binding ShopUrl}"/>
+                                        </TextBlock.InputBindings>
+                                    </TextBlock>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
                         <GridViewColumn Header="サムネイル" Width="100">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>

--- a/BoothDownloadApp/ManualAddWindow.xaml.cs
+++ b/BoothDownloadApp/ManualAddWindow.xaml.cs
@@ -15,6 +15,7 @@ namespace BoothDownloadApp
         private readonly List<string> _files = new();
         private CancellationTokenSource? _fetchCts;
         private string _lastFetchedUrl = string.Empty;
+        private string _shopUrl = string.Empty;
         public BoothItem? ResultItem { get; private set; }
         public IReadOnlyList<string> SelectedFilePaths => _files;
 
@@ -38,6 +39,7 @@ namespace BoothDownloadApp
                 {
                     ProductNameTextBox.Text = item.ProductName;
                     ShopNameTextBox.Text = item.ShopName;
+                    _shopUrl = item.ShopUrl;
                     TagsTextBox.Text = string.Join(", ", item.Tags);
                 }
                 else
@@ -58,6 +60,7 @@ namespace BoothDownloadApp
             if (string.IsNullOrWhiteSpace(url))
             {
                 _lastFetchedUrl = string.Empty;
+                _shopUrl = string.Empty;
                 return;
             }
             _fetchCts = new CancellationTokenSource();
@@ -118,6 +121,7 @@ namespace BoothDownloadApp
             {
                 ProductName = ProductNameTextBox.Text,
                 ShopName = ShopNameTextBox.Text,
+                ShopUrl = _shopUrl,
                 ItemUrl = UrlTextBox.Text.Trim(),
                 Tags = TagsTextBox.Text.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(t => t.Trim()).ToList(),
                 Downloads = downloads,


### PR DESCRIPTION
## Summary
- store shopUrl in `BoothItem`
- pass through shopUrl from json loader and product fetcher
- open product/shop pages by clicking names in the list
- remember shopUrl when manually adding items
- clear selection after successful downloads

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build BoothDownloadApp/BoothDownloadApp.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5dd37b18832daa3e476b9976f4e5