### PR TITLE
Add favorite folder auto-extraction

### DIFF
--- a/BoothDownloadApp.Core/Models/Settings.cs
+++ b/BoothDownloadApp.Core/Models/Settings.cs
@@ -7,5 +7,6 @@ namespace BoothDownloadApp
         public string DownloadPath { get; set; } = string.Empty;
         public int RetryCount { get; set; }
         public List<string> FavoriteTags { get; set; } = new List<string>();
+        public bool AutoExtractInFavorite { get; set; }
     }
 }

--- a/BoothDownloadApp.Core/Services/FavoriteFolderService.cs
+++ b/BoothDownloadApp.Core/Services/FavoriteFolderService.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+
+namespace BoothDownloadApp
+{
+    public static class FavoriteFolderService
+    {
+        public static bool CopyFileToFavorite(string sourcePath, string destFolder, bool autoExtract)
+        {
+            try
+            {
+                Directory.CreateDirectory(destFolder);
+                string destPath = Path.Combine(destFolder, Path.GetFileName(sourcePath));
+                File.Copy(sourcePath, destPath, true);
+
+                if (autoExtract && Path.GetExtension(destPath).Equals(".zip", StringComparison.OrdinalIgnoreCase))
+                {
+                    string extractDir = Path.Combine(destFolder, Path.GetFileNameWithoutExtension(sourcePath));
+                    Directory.CreateDirectory(extractDir);
+                    ZipFile.ExtractToDirectory(destPath, extractDir, true);
+                    File.Delete(destPath);
+                }
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/BoothDownloadApp.Core/Services/SettingsManager.cs
+++ b/BoothDownloadApp.Core/Services/SettingsManager.cs
@@ -28,7 +28,7 @@ namespace BoothDownloadApp
             {
                 // ignore and fall back to defaults
             }
-            return new Settings { DownloadPath = "C:\\BoothData", RetryCount = 3, FavoriteTags = new List<string>() };
+            return new Settings { DownloadPath = "C:\\BoothData", RetryCount = 3, FavoriteTags = new List<string>(), AutoExtractInFavorite = false };
         }
 
         public static void Save(Settings settings)

--- a/BoothDownloadApp/MainWindow.xaml
+++ b/BoothDownloadApp/MainWindow.xaml
@@ -145,6 +145,10 @@
             <Button Content="✏️ 編集" Width="80" Margin="5" Click="OpenEditWindow"/>
             <Button Content="＋ 手動追加" Width="80" Margin="5" Click="OpenManualAdd"/>
 
+            <Button Content="⭐ お気に入りコピー" Width="120" Margin="5" Click="CopyToFavoriteFolder"/>
+            <CheckBox Content="ZIP自動展開" Margin="5" VerticalAlignment="Center"
+                      IsChecked="{Binding AutoExtractInFavorite}"/>
+
             <Button Content="⬇️ ダウンロード開始" Width="120" Margin="5" Click="StartDownload"/>
             <Button Content="⬇️ 未DL一括" Width="120" Margin="5" Click="DownloadAllNotDownloaded"/>
             <Button Content="⏸ 停止" Width="80" Margin="5" Click="StopDownload"/>
@@ -153,6 +157,7 @@
             <ProgressBar x:Name="DownloadProgress" Height="20" Margin="20,0,10,0" VerticalAlignment="Center"
                          Minimum="0" Maximum="100" Width="200"
                          Value="{Binding Progress, Mode=OneWay}"/>
+            <TextBlock Text="{Binding StatusMessage}" Margin="10,0,0,0" VerticalAlignment="Center"/>
         </StackPanel>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- support AutoExtractInFavorite setting
- add FavoriteFolderService for optional zip extraction
- provide UI to copy to favorites and control auto-extract
- show copy result in status area

## Testing
- `dotnet --version`
- `dotnet build BoothDownloadApp/BoothDownloadApp.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f6f8a2928832da784d21b0cd00998