### PR TITLE
Add auto ZIP extraction option

### DIFF
--- a/BoothDownloadApp.Core/Models/Settings.cs
+++ b/BoothDownloadApp.Core/Models/Settings.cs
@@ -8,5 +8,6 @@ namespace BoothDownloadApp
         public int RetryCount { get; set; }
         public List<string> FavoriteTags { get; set; } = new List<string>();
         public string[] FavoriteFolders { get; set; } = new string[10];
+        public bool AutoExtractZip { get; set; }
     }
 }

--- a/BoothDownloadApp.Core/Services/SettingsManager.cs
+++ b/BoothDownloadApp.Core/Services/SettingsManager.cs
@@ -36,7 +36,8 @@ namespace BoothDownloadApp
                 DownloadPath = "C:\\BoothData",
                 RetryCount = 3,
                 FavoriteTags = new List<string>(),
-                FavoriteFolders = DefaultFolders()
+                FavoriteFolders = DefaultFolders(),
+                AutoExtractZip = false
             };
         }
 

--- a/BoothDownloadApp.Maui/MainPage.xaml.cs
+++ b/BoothDownloadApp.Maui/MainPage.xaml.cs
@@ -75,6 +75,7 @@ namespace BoothDownloadApp.Maui
                     3,
                     db,
                     new string[10],
+                    false,
                     null,
                     CancellationToken.None);
                 await DisplayAlert("Done", "Downloads completed", "OK");

--- a/BoothDownloadApp/MainWindow.xaml
+++ b/BoothDownloadApp/MainWindow.xaml
@@ -185,7 +185,9 @@
             <Button Content="⬇️ ダウンロード開始" Width="120" Margin="5" Click="StartDownload"/>
             <Button Content="⬇️ 未DL一括" Width="120" Margin="5" Click="DownloadAllNotDownloaded"/>
             <Button Content="⏸ 停止" Width="80" Margin="5" Click="StopDownload"/>
-            
+
+            <CheckBox Content="ZIP自動解凍" Margin="5" VerticalAlignment="Center" IsChecked="{Binding AutoExtractZip}"/>
+
             <!-- 進捗バーを横幅いっぱいに配置 -->
             <ProgressBar x:Name="DownloadProgress" Height="20" Margin="20,0,10,0" VerticalAlignment="Center"
                          Minimum="0" Maximum="100" Width="200"


### PR DESCRIPTION
## Summary
- persist an `AutoExtractZip` flag in `Settings`
- support new setting in `SettingsManager`
- automatically extract copied ZIP archives in `DownloadService`
- expose a checkbox in the main window bound to this flag
- track extraction status when updating item info
- update MAUI page and download logic to pass setting

## Testing
- `dotnet build BoothDownloadApp.sln` *(fails: missing workloads)*
- `dotnet build BoothDownloadApp/BoothDownloadApp.csproj` *(fails: missing WindowsDesktop targets)*

------
https://chatgpt.com/codex/tasks/task_e_684f83d6bda8832db214bd44b6805a4c