### PR TITLE
Fix several crashes and runtime issues

### DIFF
--- a/BoothDownloadApp.Core/Services/DatabaseManager.cs
+++ b/BoothDownloadApp.Core/Services/DatabaseManager.cs
@@ -42,7 +42,8 @@ CREATE TABLE IF NOT EXISTS ItemTags (ItemId INTEGER, TagId INTEGER, UNIQUE(ItemI
             insert.ExecuteNonQuery();
             using var select = new SQLiteCommand("SELECT Id FROM Tags WHERE Name=@name;", connection);
             select.Parameters.AddWithValue("@name", tag);
-            return (long)select.ExecuteScalar();
+            object? result = select.ExecuteScalar();
+            return Convert.ToInt64(result ?? 0);
         }
 
         private static long EnsureItem(string name, string url, SQLiteConnection connection)
@@ -53,7 +54,8 @@ CREATE TABLE IF NOT EXISTS ItemTags (ItemId INTEGER, TagId INTEGER, UNIQUE(ItemI
             insert.ExecuteNonQuery();
             using var select = new SQLiteCommand("SELECT Id FROM History WHERE URL=@url;", connection);
             select.Parameters.AddWithValue("@url", url);
-            return (long)select.ExecuteScalar();
+            object? result = select.ExecuteScalar();
+            return Convert.ToInt64(result ?? 0);
         }
 
         private static void SaveItemWithTags(string name, string url, List<string> tags, SQLiteConnection connection)

--- a/BoothDownloadApp.Core/Services/DownloadService.cs
+++ b/BoothDownloadApp.Core/Services/DownloadService.cs
@@ -64,7 +64,25 @@ namespace BoothDownloadApp
                                         Directory.CreateDirectory(extractDir);
                                         try
                                         {
-                                            ZipFile.ExtractToDirectory(dest, extractDir, true);
+                                            using ZipArchive archive = ZipFile.OpenRead(dest);
+                                            string extractRoot = Path.GetFullPath(extractDir);
+                                            foreach (var entry in archive.Entries)
+                                            {
+                                                string entryDest = Path.GetFullPath(Path.Combine(extractDir, entry.FullName));
+                                                if (!entryDest.StartsWith(extractRoot, StringComparison.Ordinal))
+                                                {
+                                                    continue;
+                                                }
+                                                if (string.IsNullOrEmpty(entry.Name))
+                                                {
+                                                    Directory.CreateDirectory(entryDest);
+                                                }
+                                                else
+                                                {
+                                                    Directory.CreateDirectory(Path.GetDirectoryName(entryDest)!);
+                                                    entry.ExtractToFile(entryDest, true);
+                                                }
+                                            }
                                             File.Delete(dest);
                                         }
                                         catch { }

--- a/BoothDownloadApp.Core/Services/JsonLoader.cs
+++ b/BoothDownloadApp.Core/Services/JsonLoader.cs
@@ -26,7 +26,10 @@ namespace BoothDownloadApp
                     }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to parse BoothLibrary JSON: {ex.Message}");
+            }
             try
             {
                 var simple = JsonSerializer.Deserialize<List<SimpleBoothItem>>(json, options);
@@ -49,7 +52,10 @@ namespace BoothDownloadApp
                     }).ToList();
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to parse SimpleBoothItem JSON: {ex.Message}");
+            }
             return null;
         }
     }

--- a/BoothDownloadApp/MainWindow.xaml.cs
+++ b/BoothDownloadApp/MainWindow.xaml.cs
@@ -572,8 +572,11 @@ namespace BoothDownloadApp
                     var fetched = await ProductFetcher.FetchItemAsync(item.ItemUrl);
                     if (fetched != null)
                     {
-                        item.Tags = fetched.Tags;
-                        item.TagsFetched = true;
+                        await Dispatcher.InvokeAsync(() =>
+                        {
+                            item.Tags = fetched.Tags;
+                            item.TagsFetched = true;
+                        });
                     }
                 }
             });
@@ -661,6 +664,7 @@ namespace BoothDownloadApp
                 }
                 Items.Add(item);
                 SaveManagementData();
+            }
             UpdateDownloadStatus();
         }
 


### PR DESCRIPTION
## Summary
- close `OpenManualAdd` code block
- guard `ExecuteScalar` results in `DatabaseManager`
- update bound properties on the UI thread when fetching tags
- report JSON parsing failures instead of suppressing them
- safely extract zip files by validating entry paths

## Testing
- `dotnet build -c Release` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f9536a180832d8a3ba5ef81ea5fad