### PR TITLE
Fix compile errors and add missing manifests

### DIFF
--- a/BoothDownloadApp.Core/Services/DownloadService.cs
+++ b/BoothDownloadApp.Core/Services/DownloadService.cs
@@ -66,21 +66,21 @@ namespace BoothDownloadApp
                                         {
                                             using ZipArchive archive = ZipFile.OpenRead(dest);
                                             string extractRoot = Path.GetFullPath(extractDir);
-                                            foreach (var entry in archive.Entries)
+                                            foreach (var zipEntry in archive.Entries)
                                             {
-                                                string entryDest = Path.GetFullPath(Path.Combine(extractDir, entry.FullName));
+                                                string entryDest = Path.GetFullPath(Path.Combine(extractDir, zipEntry.FullName));
                                                 if (!entryDest.StartsWith(extractRoot, StringComparison.Ordinal))
                                                 {
                                                     continue;
                                                 }
-                                                if (string.IsNullOrEmpty(entry.Name))
+                                                if (string.IsNullOrEmpty(zipEntry.Name))
                                                 {
                                                     Directory.CreateDirectory(entryDest);
                                                 }
                                                 else
                                                 {
                                                     Directory.CreateDirectory(Path.GetDirectoryName(entryDest)!);
-                                                    entry.ExtractToFile(entryDest, true);
+                                                    zipEntry.ExtractToFile(entryDest, true);
                                                 }
                                             }
                                             File.Delete(dest);

--- a/BoothDownloadApp.Maui/Platforms/Android/AndroidManifest.xml
+++ b/BoothDownloadApp.Maui/Platforms/Android/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:label="BoothDownloadApp" android:theme="@style/Maui.SplashTheme">
+        <activity android:name="crc64a5a37c43dff01024.MainActivity"
+                  android:exported="true"
+                  android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+                  android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/BoothDownloadApp.Maui/Platforms/Windows/Package.appxmanifest
+++ b/BoothDownloadApp.Maui/Platforms/Windows/Package.appxmanifest
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  IgnorableNamespaces="uap mp">
+  <Identity Name="BoothDownloadApp.Maui" Publisher="CN=BoothDownloadApp" Version="1.0.0.0" />
+  <Properties>
+    <DisplayName>BoothDownloadApp</DisplayName>
+    <PublisherDisplayName>BoothDownloadApp</PublisherDisplayName>
+    <Logo>Assets\Square150x150Logo.png</Logo>
+  </Properties>
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+  <Applications>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="BoothDownloadApp.Maui.WinUI.App">
+      <uap:VisualElements DisplayName="BoothDownloadApp" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="BoothDownloadApp" BackgroundColor="transparent" />
+    </Application>
+  </Applications>
+</Package>


### PR DESCRIPTION
## Summary
- avoid variable name shadowing in `DownloadService`
- add Android and Windows manifest files for MAUI project

## Testing
- `dotnet build BoothDownloadApp/BoothDownloadApp.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff24d8930832d970de319ee54d3b5