### PR TITLE
Restrict MAUI project to Windows

### DIFF
--- a/BoothDownloadApp.Maui/BoothDownloadApp.Maui.csproj
+++ b/BoothDownloadApp.Maui/BoothDownloadApp.Maui.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BoothDownloadApp.Core\BoothDownloadApp.Core.csproj" />

--- a/BoothDownloadApp/BoothDownloadApp.csproj
+++ b/BoothDownloadApp/BoothDownloadApp.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- target Windows exclusively in MAUI project
- enable Windows targeting in the WPF project

## Testing
- `dotnet build BoothDownloadApp.Core/BoothDownloadApp.Core.csproj -nologo`
- `dotnet build BoothDownloadApp/BoothDownloadApp.csproj -nologo` *(failed: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff56c587c832d9373cefe5a2ff7ff