### PR TITLE
Enable per-file favorite folder assignment

### DIFF
--- a/BoothDownloadApp.Core/Models/BoothItem.cs
+++ b/BoothDownloadApp.Core/Models/BoothItem.cs
@@ -124,6 +124,21 @@ namespace BoothDownloadApp
             [JsonPropertyName("downloadLink")]
             public string DownloadLink { get; set; } = string.Empty;
 
+            private int _favoriteFolderIndex = -1;
+            [JsonPropertyName("favoriteFolderIndex")]
+            public int FavoriteFolderIndex
+            {
+                get => _favoriteFolderIndex;
+                set
+                {
+                    if (_favoriteFolderIndex != value)
+                    {
+                        _favoriteFolderIndex = value;
+                        OnPropertyChanged();
+                    }
+                }
+            }
+
             [JsonPropertyName("description")]
             public string Description
             {

--- a/BoothDownloadApp.Core/Services/DownloadService.cs
+++ b/BoothDownloadApp.Core/Services/DownloadService.cs
@@ -45,9 +45,10 @@ namespace BoothDownloadApp
                         progress?.Report((int)((double)downloaded / totalFiles * 100));
                         db.SaveHistoryItem(PathUtils.Sanitize(entry.file.FileName), entry.file.DownloadLink);
 
-                        if (entry.item.FavoriteFolderIndex >= 0 && entry.item.FavoriteFolderIndex < favoriteFolders.Length)
+                        int folderIdx = entry.file.FavoriteFolderIndex >= 0 ? entry.file.FavoriteFolderIndex : entry.item.FavoriteFolderIndex;
+                        if (folderIdx >= 0 && folderIdx < favoriteFolders.Length)
                         {
-                            string favRoot = favoriteFolders[entry.item.FavoriteFolderIndex];
+                            string favRoot = favoriteFolders[folderIdx];
                             if (!string.IsNullOrWhiteSpace(favRoot))
                             {
                                 string favFolder = Path.Combine(favRoot,

--- a/BoothDownloadApp/FavoriteFolderAssignWindow.xaml
+++ b/BoothDownloadApp/FavoriteFolderAssignWindow.xaml
@@ -1,0 +1,34 @@
+<Window x:Class="BoothDownloadApp.FavoriteFolderAssignWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="お気に入りフォルダ割り当て" Height="400" Width="500">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
+            <TextBlock Text="アイテム:" VerticalAlignment="Center" />
+            <TextBlock Text="{Binding ProductName}" FontWeight="Bold" Margin="5,0,0,0" VerticalAlignment="Center" />
+            <TextBlock Text=" フォルダ:" Margin="20,0,0,0" VerticalAlignment="Center" />
+            <ComboBox Width="120" ItemsSource="{Binding FolderNames}" SelectedIndex="{Binding ItemFolderIndex}" />
+        </StackPanel>
+        <DataGrid Grid.Row="1" ItemsSource="{Binding Item.Downloads}" AutoGenerateColumns="False">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="ファイル名" Binding="{Binding FileName}" Width="200" />
+                <DataGridTemplateColumn Header="フォルダ" Width="120">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <ComboBox Width="100" ItemsSource="{Binding DataContext.FolderNames, RelativeSource={RelativeSource AncestorType=Window}}" SelectedIndex="{Binding FavoriteFolderIndex}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Width="80" Margin="5" Click="Ok_Click" />
+            <Button Content="キャンセル" Width="80" Margin="5" Click="Cancel_Click" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/BoothDownloadApp/FavoriteFolderAssignWindow.xaml.cs
+++ b/BoothDownloadApp/FavoriteFolderAssignWindow.xaml.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+
+namespace BoothDownloadApp
+{
+    public partial class FavoriteFolderAssignWindow : Window
+    {
+        public IList<string> FolderNames { get; }
+        public BoothItem Item { get; }
+        public int ItemFolderIndex { get; set; }
+
+        public FavoriteFolderAssignWindow(BoothItem item, IList<string> folderNames)
+        {
+            InitializeComponent();
+            Item = item;
+            FolderNames = folderNames;
+            ItemFolderIndex = item.FavoriteFolderIndex;
+            DataContext = this;
+        }
+
+        private void Ok_Click(object sender, RoutedEventArgs e)
+        {
+            Item.FavoriteFolderIndex = ItemFolderIndex;
+            foreach (var d in Item.Downloads)
+            {
+                // leave individual index as is if user didn't change
+            }
+            DialogResult = true;
+            Close();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}

--- a/BoothDownloadApp/MainWindow.xaml
+++ b/BoothDownloadApp/MainWindow.xaml
@@ -44,6 +44,7 @@
                 <TextBlock Text="検索" Margin="0,10,0,0"/>
                 <TextBox Width="150" Margin="0,0,0,5" Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}" TextChanged="FilterChanged"/>
                 <Button Content="📁 フォルダ設定" Width="120" Margin="0,0,0,5" Click="OpenFavoriteFolderSetting"/>
+                <Button Content="📌 フォルダ割り当て" Width="120" Margin="0,0,0,5" Click="OpenFavoriteFolderAssign"/>
                 <TabControl Margin="0,5,0,5" SelectedIndex="{Binding SelectedFavoriteFolderIndex}">
                     <TabItem Header="All" />
                     <TabItem Header="{Binding FavoriteFolderNames[0]}" Visibility="{Binding FavoriteFolderUsed[0], Converter={StaticResource BoolToVisibilityConverter}}" />


### PR DESCRIPTION
## Summary
- support per-download favorite folder choice in BoothItem
- copy downloads to chosen folder on download
- show a dialog for assigning folders to items and files
- add button in main window to open the new dialog

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build BoothDownloadApp.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_68501e71cc10832d9dbb042c0355389c