### PR TITLE
Add filter for unassigned favorite folders

### DIFF
--- a/BoothDownloadApp.Core/Services/FilterManager.cs
+++ b/BoothDownloadApp.Core/Services/FilterManager.cs
@@ -25,9 +25,19 @@ namespace BoothDownloadApp
                 return false;
             }
 
-            if (favoriteFolderIndex >= 0 && item.FavoriteFolderIndex != favoriteFolderIndex)
+            if (favoriteFolderIndex >= 0)
             {
-                return false;
+                if (item.FavoriteFolderIndex != favoriteFolderIndex)
+                {
+                    return false;
+                }
+            }
+            else if (favoriteFolderIndex == -2)
+            {
+                if (item.FavoriteFolderIndex >= 0)
+                {
+                    return false;
+                }
             }
 
             if (showOnlyUpdates)

--- a/BoothDownloadApp/FavoriteFolderAssignWindow.xaml
+++ b/BoothDownloadApp/FavoriteFolderAssignWindow.xaml
@@ -1,7 +1,11 @@
 <Window x:Class="BoothDownloadApp.FavoriteFolderAssignWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:BoothDownloadApp"
         Title="お気に入りフォルダ割り当て" Height="400" Width="500">
+    <Window.Resources>
+        <local:IndexOffsetConverter x:Key="IndexOffsetConverter"/>
+    </Window.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -12,7 +16,7 @@
             <TextBlock Text="アイテム:" VerticalAlignment="Center" />
             <TextBlock Text="{Binding ProductName}" FontWeight="Bold" Margin="5,0,0,0" VerticalAlignment="Center" />
             <TextBlock Text=" フォルダ:" Margin="20,0,0,0" VerticalAlignment="Center" />
-            <ComboBox Width="120" ItemsSource="{Binding FolderNames}" SelectedIndex="{Binding ItemFolderIndex}" />
+            <ComboBox Width="120" ItemsSource="{Binding FolderNamesWithNone}" SelectedIndex="{Binding SelectedIndex}" />
         </StackPanel>
         <DataGrid Grid.Row="1" ItemsSource="{Binding Item.Downloads}" AutoGenerateColumns="False">
             <DataGrid.Columns>
@@ -20,7 +24,9 @@
                 <DataGridTemplateColumn Header="フォルダ" Width="120">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <ComboBox Width="100" ItemsSource="{Binding DataContext.FolderNames, RelativeSource={RelativeSource AncestorType=Window}}" SelectedIndex="{Binding FavoriteFolderIndex}" />
+                            <ComboBox Width="100"
+                                     ItemsSource="{Binding DataContext.FolderNamesWithNone, RelativeSource={RelativeSource AncestorType=Window}}"
+                                     SelectedIndex="{Binding FavoriteFolderIndex, Converter={StaticResource IndexOffsetConverter}, ConverterParameter=1}" />
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/BoothDownloadApp/FavoriteFolderAssignWindow.xaml.cs
+++ b/BoothDownloadApp/FavoriteFolderAssignWindow.xaml.cs
@@ -7,21 +7,23 @@ namespace BoothDownloadApp
     public partial class FavoriteFolderAssignWindow : Window
     {
         public IList<string> FolderNames { get; }
+        public IList<string> FolderNamesWithNone { get; }
         public BoothItem Item { get; }
-        public int ItemFolderIndex { get; set; }
+        public int SelectedIndex { get; set; }
 
         public FavoriteFolderAssignWindow(BoothItem item, IList<string> folderNames)
         {
             InitializeComponent();
             Item = item;
             FolderNames = folderNames;
-            ItemFolderIndex = item.FavoriteFolderIndex;
+            FolderNamesWithNone = new[] { "未選択" }.Concat(folderNames).ToList();
+            SelectedIndex = item.FavoriteFolderIndex + 1;
             DataContext = this;
         }
 
         private void Ok_Click(object sender, RoutedEventArgs e)
         {
-            Item.FavoriteFolderIndex = ItemFolderIndex;
+            Item.FavoriteFolderIndex = SelectedIndex - 1;
             foreach (var d in Item.Downloads)
             {
                 // leave individual index as is if user didn't change

--- a/BoothDownloadApp/IndexOffsetConverter.cs
+++ b/BoothDownloadApp/IndexOffsetConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace BoothDownloadApp
+{
+    /// <summary>
+    /// Converter that adds an offset to an index when converting and subtracts
+    /// it when converting back. Used for mapping ComboBox SelectedIndex
+    /// values when an additional "none" option is inserted.
+    /// </summary>
+    public class IndexOffsetConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            int offset = System.Convert.ToInt32(parameter);
+            int index = System.Convert.ToInt32(value);
+            return index + offset;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            int offset = System.Convert.ToInt32(parameter);
+            int index = System.Convert.ToInt32(value);
+            return index - offset;
+        }
+    }
+}

--- a/BoothDownloadApp/MainWindow.xaml
+++ b/BoothDownloadApp/MainWindow.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="BoothDownloadApp.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:BoothDownloadApp"
         Title="Boothダウンロードアプリ" Height="600" Width="800">
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
@@ -47,6 +48,7 @@
                 <Button Content="📌 フォルダ割り当て" Width="120" Margin="0,0,0,5" Click="OpenFavoriteFolderAssign"/>
                 <TabControl Margin="0,5,0,5" SelectedIndex="{Binding SelectedFavoriteFolderIndex}">
                     <TabItem Header="All" />
+                    <TabItem Header="未選択" />
                     <TabItem Header="{Binding FavoriteFolderNames[0]}" Visibility="{Binding FavoriteFolderUsed[0], Converter={StaticResource BoolToVisibilityConverter}}" />
                     <TabItem Header="{Binding FavoriteFolderNames[1]}" Visibility="{Binding FavoriteFolderUsed[1], Converter={StaticResource BoolToVisibilityConverter}}" />
                     <TabItem Header="{Binding FavoriteFolderNames[2]}" Visibility="{Binding FavoriteFolderUsed[2], Converter={StaticResource BoolToVisibilityConverter}}" />

--- a/BoothDownloadApp/MainWindow.xaml.cs
+++ b/BoothDownloadApp/MainWindow.xaml.cs
@@ -133,7 +133,7 @@ namespace BoothDownloadApp
             }
         }
 
-        private int _selectedFavoriteFolderIndex = -1;
+        private int _selectedFavoriteFolderIndex = 0; // "All" tab by default
         public int SelectedFavoriteFolderIndex
         {
             get => _selectedFavoriteFolderIndex;
@@ -616,10 +616,24 @@ namespace BoothDownloadApp
         {
             if (ItemsView == null) return;
 
+            int filterIndex;
+            if (SelectedFavoriteFolderIndex == 0)
+            {
+                filterIndex = -1; // All
+            }
+            else if (SelectedFavoriteFolderIndex == 1)
+            {
+                filterIndex = -2; // Unassigned only
+            }
+            else
+            {
+                filterIndex = SelectedFavoriteFolderIndex - 2;
+            }
+
             ItemsView.Filter = obj =>
             {
                 if (obj is not BoothItem item) return false;
-                return FilterManager.Matches(item, ShowOnlyNotDownloaded, SelectedTag, ShowOnlyUpdates, SearchQuery, ShowOnlyFavorites, FavoriteTags, SelectedFavoriteFolderIndex);
+                return FilterManager.Matches(item, ShowOnlyNotDownloaded, SelectedTag, ShowOnlyUpdates, SearchQuery, ShowOnlyFavorites, FavoriteTags, filterIndex);
             };
 
             ItemsView.Refresh();


### PR DESCRIPTION
## Summary
- allow selecting items without favorite folder
- adjust filter logic to support the new tab
- provide combo box option for clearing folder assignment
- add index converter utility

## Testing
- `dotnet build BoothDownloadApp.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850b183f274832da68409319cfeb546