### PR TITLE
Add login check on startup

### DIFF
--- a/BoothDownloadApp.Core/Services/LoginManager.cs
+++ b/BoothDownloadApp.Core/Services/LoginManager.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace BoothDownloadApp
+{
+    public static class LoginManager
+    {
+        public static async Task<bool> IsLoggedInAsync()
+        {
+            CookieContainer cookies = CookieStore.Load();
+            using HttpClientHandler handler = new HttpClientHandler { CookieContainer = cookies, AllowAutoRedirect = true };
+            using HttpClient client = new HttpClient(handler);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+                "AppleWebKit/537.36 (KHTML, like Gecko) " +
+                "Chrome/123.0.0.0 Safari/537.36");
+            try
+            {
+                using HttpResponseMessage response = await client.GetAsync("https://accounts.booth.pm/library");
+                string finalUrl = response.RequestMessage?.RequestUri?.ToString() ?? string.Empty;
+                if (finalUrl.Contains("sign_in") || finalUrl.Contains("login"))
+                {
+                    return false;
+                }
+                return response.IsSuccessStatusCode;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/BoothDownloadApp/App.xaml.cs
+++ b/BoothDownloadApp/App.xaml.cs
@@ -1,15 +1,20 @@
-﻿using System.Windows;
+﻿using System.Threading.Tasks;
+using System.Windows;
 
 namespace BoothDownloadApp
 {
     public partial class App : Application
     {
-        protected override void OnStartup(StartupEventArgs e)
+        protected override async void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
 
-            var loginWindow = new LoginWindow();
-            loginWindow.ShowDialog();
+            bool loggedIn = await LoginManager.IsLoggedInAsync();
+            if (!loggedIn)
+            {
+                var loginWindow = new LoginWindow();
+                loginWindow.ShowDialog();
+            }
 
             MainWindow mainWindow = new MainWindow();
             MainWindow = mainWindow;


### PR DESCRIPTION
## Summary
- add `LoginManager` to verify saved cookies
- show login dialog only when not logged in

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build BoothDownloadApp.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f0406844832da29d3b28d7a35936