### PR TITLE
Fix login page link

### DIFF
--- a/BoothDownloadApp/LoginWindow.xaml.cs
+++ b/BoothDownloadApp/LoginWindow.xaml.cs
@@ -18,7 +18,7 @@ namespace BoothDownloadApp
         private async void LoginWindow_Loaded(object sender, RoutedEventArgs e)
         {
             await Browser.EnsureCoreWebView2Async();
-            Browser.CoreWebView2.Navigate("https://accounts.booth.pm/login");
+            Browser.CoreWebView2.Navigate("https://accounts.booth.pm/users/sign_in");
         }
 
         protected override async void OnClosed(EventArgs e)


### PR DESCRIPTION
## Summary
- update login URL to `https://accounts.booth.pm/users/sign_in`

## Testing
- `dotnet build BoothDownloadApp.sln -c Release -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f982ee00832d9c0eefd97f66b7e7