### PR TITLE
Fix Clipboard namespace ambiguity

### DIFF
--- a/BoothDownloadApp/MainWindow.xaml.cs
+++ b/BoothDownloadApp/MainWindow.xaml.cs
@@ -7,7 +7,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Windows;
 using MessageBox = System.Windows.MessageBox; // WPF の MessageBox を明示的に指定
-using System.Windows.Forms;
 using OpenFileDialog = Microsoft.Win32.OpenFileDialog;
 using Microsoft.WindowsAPICodePack.Dialogs;
 using System.Net.Http;


### PR DESCRIPTION
## Summary
- remove the System.Windows.Forms using from MainWindow to avoid the Clipboard type conflict

## Testing
- dotnet build BoothDownloadApp.sln


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69216e66797c832d92cc5a2a09d1a52a)